### PR TITLE
feat: comprehensive test suite and security properties docs

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -91,13 +91,23 @@ sequenceDiagram
 
 ## Security Properties
 
-1. **Ownership** — only the token owner can modify or destroy a token.
+The validators enforce 17 invariants across 12 categories, each
+verified by the inline test suite (44 tests / 242 checks):
+
+1. **Ownership** — only the oracle (token owner) can modify or destroy a token.
 2. **Integrity** — every MPF modification carries a cryptographic proof
-   verified on-chain.
+   verified on-chain; the output root must match the proof computation.
 3. **Uniqueness** — token IDs are derived from spent UTxOs, guaranteed
    unique by the ledger.
-4. **Retractability** — request owners can always reclaim their locked ADA.
-5. **Verifiability** — all changes are traceable via blockchain history.
+4. **Confinement** — the token must remain at the script address after
+   every operation.
+5. **Retractability** — request owners can always reclaim their locked ADA.
+6. **Type safety** — each redeemer/datum combination is enforced; mismatches
+   are rejected.
+7. **Verifiability** — all changes are traceable via blockchain history.
+
+See [Security Properties](properties.md) for the complete list with
+test cross-references.
 
 ## Aiken Dependencies
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,9 +2,14 @@
 
 ## System Context
 
-The on-chain validators are one half of the MPFS system. They
-enforce the rules for creating, updating, and destroying MPF
-token instances on the Cardano blockchain.
+The on-chain validators are one half of the
+[MPFS system](https://github.com/cardano-foundation/mpfs)
+([documentation](https://cardano-foundation.github.io/mpfs/)).
+They enforce the rules for creating, updating, and destroying MPF
+token instances on the Cardano blockchain. The off-chain service
+that builds transactions and manages the trie lives in the
+[`off_chain/`](https://github.com/cardano-foundation/mpfs/tree/main/off_chain)
+directory of the upstream repository.
 
 ```mermaid
 architecture-beta
@@ -111,17 +116,8 @@ test cross-references.
 
 ## Aiken Dependencies
 
-```toml
-name = "hal/mpf"
-version = "0.0.0"
-compiler = "v1.1.16"
-plutus = "v3"
-
-[[dependencies]]
-name = "aiken-lang/stdlib"
-version = "v2.2.0"
-
-[[dependencies]]
-name = "aiken-lang/merkle-patricia-forestry"
-version = "v2.0.0"
-```
+| Dependency | Version | Purpose |
+|---|---|---|
+| [aiken-lang/stdlib](https://github.com/aiken-lang/stdlib) | v2.2.0 | Standard library (assets, transactions, addresses) |
+| [aiken-lang/merkle-patricia-forestry](https://github.com/aiken-lang/merkle-patricia-forestry) | v2.0.0 | MPF trie operations and proof verification |
+| [aiken-lang/fuzz](https://github.com/aiken-lang/fuzz) | v2.1.1 | Property-based testing (used in test suite only) |

--- a/docs/architecture/proofs.md
+++ b/docs/architecture/proofs.md
@@ -1,8 +1,9 @@
 # Proof System
 
-The on-chain validators verify Merkle Patricia Forestry (MPF)
-proofs to ensure that every trie modification is cryptographically
-valid.
+The on-chain validators verify
+[Merkle Patricia Forestry](https://github.com/aiken-lang/merkle-patricia-forestry)
+(MPF) proofs to ensure that every trie modification is
+cryptographically valid.
 
 ## MPF Structure
 

--- a/docs/architecture/properties.md
+++ b/docs/architecture/properties.md
@@ -6,8 +6,13 @@ with the test(s) that verify it.
 
 The properties are derived from the
 [upstream MPFS specification](https://cardano-foundation.github.io/mpfs/)
-and verified by the inline test suite. Run `aiken check` (or `just test`)
-to check all 44 tests / 242 checks.
+([architecture](https://cardano-foundation.github.io/mpfs/architecture/),
+[on-chain code docs](https://cardano-foundation.github.io/mpfs/code/on-chain/))
+and verified by the inline test suite in
+[`cage.ak`](https://github.com/cardano-foundation/mpfs/blob/main/on_chain/validators/cage.ak)
+and
+[`lib.ak`](https://github.com/cardano-foundation/mpfs/blob/main/on_chain/validators/lib.ak).
+Run `aiken check` (or `just test`) to check all 44 tests / 242 checks.
 
 ---
 

--- a/docs/architecture/properties.md
+++ b/docs/architecture/properties.md
@@ -1,0 +1,272 @@
+# Security Properties
+
+This page documents the on-chain security properties of the MPF Cage
+validators. Each property is stated as an invariant and cross-referenced
+with the test(s) that verify it.
+
+The properties are derived from the
+[upstream MPFS specification](https://cardano-foundation.github.io/mpfs/)
+and verified by the inline test suite. Run `aiken check` (or `just test`)
+to check all 44 tests / 242 checks.
+
+---
+
+## Roles
+
+The upstream MPFS documentation defines three roles:
+
+- **Oracle** (token owner): controls which facts are added or removed
+  from an MPF token. Maps to the `State.owner` field.
+- **Requester**: proposes fact changes via `RequestDatum` UTxOs. Maps
+  to `Request.requestOwner`.
+- **Observer**: reads the MPF state from the blockchain. No on-chain
+  role; all knowledge is reconstructable from the chain history.
+
+The on-chain validators enforce the boundaries between these roles.
+
+---
+
+## On-chain vs Off-chain Guarantees
+
+The validators enforce **what must hold on-chain**. Some guarantees
+depend on off-chain behaviour:
+
+| Guarantee | Enforced by |
+|---|---|
+| Token identity is unique | On-chain (UTxO consumption) |
+| Only the oracle can update the MPF root | On-chain (signature check) |
+| Every modification carries a valid Merkle proof | On-chain (proof verification) |
+| Output root matches proof computation | On-chain (fold + compare) |
+| Token stays at the script address | On-chain (address check) |
+| Requesters can always reclaim locked ADA | On-chain (Retract path) |
+| The oracle honestly processes matching requests | Off-chain (oracle behaviour) |
+| Proofs are computed against the correct trie state | Off-chain (proof generation) |
+| All knowledge is reconstructable from history | Blockchain (ledger property) |
+
+---
+
+## 1. Token Uniqueness
+
+> *Upstream: "The new token-id is unique"*
+
+**Invariant:** Two distinct `OutputReference` values always produce
+different token asset names.
+
+The asset name is `SHA2-256(tx_id ++ output_index)`. Since an
+`OutputReference` can only be consumed once, the minting policy
+guarantees that no two tokens share the same identity.
+
+| Property | Test | File |
+|---|---|---|
+| Same reference yields same hash (deterministic) | `assetName_deterministic` | `lib.ak` |
+| Different `tx_id` yields different hash | `assetName_different_txid` | `lib.ak` |
+| Different `output_index` yields different hash | `assetName_different_index` | `lib.ak` |
+| Determinism holds for arbitrary references | `prop_assetName_deterministic` | `lib.ak` |
+
+## 2. Minting Integrity
+
+> *Upstream: "The hash in the token is null" (at boot)*
+
+**Invariant:** A token can only be minted when all of the following
+hold simultaneously:
+
+1. The `OutputReference` is consumed in the transaction.
+2. Exactly one token is minted (quantity = 1).
+3. The output goes to the validator's own script address.
+4. The output carries a `StateDatum` with `root = root(empty)`.
+
+Violating any single condition causes the minting policy to reject
+the transaction.
+
+| Property | Test | Violated condition |
+|---|---|---|
+| Happy path (all conditions met) | `canMint` | -- |
+| Reference not consumed | `mint_missing_input` | (1) |
+| Quantity = 2 | `mint_quantity_two` | (2) |
+| Output to wallet address | `mint_to_wallet` | (3) |
+| Output to different script | `mint_to_wrong_script` | (3) |
+| Non-empty initial root | `mint_nonempty_root` | (4) |
+| Datum is `RequestDatum` | `mint_request_datum` | (4) |
+| Output has `NoDatum` | `mint_no_datum` | (4) |
+| Roundtrip: any valid reference produces a valid mint | `prop_mint_roundtrip` | -- |
+
+## 3. Ownership & Authorization
+
+> *Upstream: "MPF tokens can be modified only by their owner"*
+
+**Invariant:** Only the holder of the correct verification key can
+perform privileged operations.
+
+- **Modify / End** (oracle operations): require the `State.owner`
+  signature.
+- **Retract** (requester operation): requires the
+  `Request.requestOwner` signature.
+- **Contribute**: permissionless — anyone can link a request to a
+  state UTxO.
+
+| Property | Test | Operation |
+|---|---|---|
+| Oracle signs Modify | `canCage` | Modify |
+| Missing oracle signature blocks Modify | `modify_missing_signature` | Modify |
+| Missing oracle signature blocks End | `end_missing_signature` | End |
+| Requester signs Retract | `retract_happy` | Retract |
+| Wrong signer blocks Retract | `retract_wrong_signer` | Retract |
+| Random signer != requester fails Retract | `prop_retract_requires_owner` | Retract |
+| Random signer != oracle fails Modify | `prop_modify_requires_owner` | Modify |
+
+## 4. Token Confinement
+
+**Invariant:** The caged token must remain at the same script
+address after a `Modify` operation. The output's payment credential
+must equal the input's payment credential.
+
+This prevents the oracle from extracting the token to a wallet or
+redirecting it to a different script during an update.
+
+| Property | Test |
+|---|---|
+| Output to different script address is rejected | `modify_wrong_address` |
+| Output to same address succeeds | `canCage`, `modify_owner_transfer` |
+
+## 5. Ownership Transfer
+
+**Invariant:** The `owner` field in the output datum is **not**
+checked against the input datum during `Modify`. The current oracle
+can transfer ownership to a new key by changing the `owner` field.
+
+This is intentional: it enables oracle rotation and delegation
+without burning and re-minting.
+
+| Property | Test |
+|---|---|
+| Owner changes from `"owner"` to `"new-owner"` | `modify_owner_transfer` |
+| Existing happy path demonstrates transfer | `canCage` |
+
+## 6. State Integrity (MPF Root)
+
+> *Upstream: "All modifications to an MPF root have to appear
+> on-chain" and "All modifications must be consumed under a smart
+> contract validation"*
+
+**Invariant:** The output root must exactly match the result of
+folding all matching request operations over the input root using
+the provided Merkle proofs. A wrong claimed root is rejected.
+
+This is the core cryptographic guarantee: every state transition
+is provably correct.
+
+| Property | Test |
+|---|---|
+| Correct root after one Insert | `canCage` |
+| Wrong root in output datum | `modify_wrong_root` |
+| No requests: root must stay unchanged | `modify_no_requests` |
+| Requests for other tokens are skipped | `modify_skip_other_token` |
+
+## 7. Proof Consumption
+
+**Invariant:** Exactly one Merkle proof is consumed per matching
+request input. Too few proofs causes failure (`uncons` on empty
+list). Extra proofs are silently ignored.
+
+| Property | Test |
+|---|---|
+| One proof per request (happy path) | `canCage` |
+| Zero proofs for one request | `modify_too_few_proofs` |
+| Two proofs for one request (extra ignored) | `modify_extra_proofs` |
+
+!!! note
+    The validator does not reject extra proofs. This is a design
+    choice: it simplifies transaction building when the exact
+    number of matching requests is uncertain at construction time.
+
+## 8. Request Binding
+
+> *Upstream: "All consumed requests reference the token being updated"*
+
+**Invariant:** A `Contribute` transaction validates that the
+request's `requestToken` matches the actual token at the referenced
+State UTxO. Requests targeting a different token are rejected.
+
+This prevents a request intended for token A from being applied
+to token B.
+
+| Property | Test |
+|---|---|
+| Matching token succeeds | `canCage` |
+| Mismatched token | `contribute_wrong_token` |
+| Referenced UTxO not in inputs | `contribute_missing_ref` |
+
+## 9. Datum-Redeemer Type Safety
+
+**Invariant:** Each redeemer expects a specific datum constructor.
+Using the wrong combination causes the `expect` pattern match to
+fail, rejecting the transaction.
+
+This enforces a clean separation between State UTxOs (oracle
+operations) and Request UTxOs (requester operations).
+
+| Redeemer | Required datum | Wrong datum test |
+|---|---|---|
+| `Retract` | `RequestDatum` | `retract_on_state_datum` |
+| `Contribute` | `RequestDatum` | `contribute_on_state_datum` |
+| `Modify` | `StateDatum` | `modify_on_request_datum` |
+| `End` | `StateDatum` | `end_on_request_datum` |
+
+## 10. Datum Presence
+
+**Invariant:** The spending validator requires `Some(datum)`. A
+UTxO with no datum (e.g. accidentally sent ADA to the script
+address) cannot be spent through any redeemer.
+
+| Property | Test |
+|---|---|
+| `None` datum rejected | `spend_no_datum` |
+
+## 11. End / Burn Integrity
+
+**Invariant:** The `End` redeemer verifies that the mint field
+contains exactly the same token being burned. Burning a different
+token while keeping the caged one is rejected.
+
+| Property | Test |
+|---|---|
+| Correct token burned | `end_happy` |
+| Different token in mint field | `end_wrong_token_in_mint` |
+
+## 12. Token Extraction
+
+**Invariant:** `tokenFromValue` returns `Some(TokenId)` only when
+the value contains exactly one non-ADA policy with exactly one
+asset name. All other shapes return `None`.
+
+This is a safety function used throughout the validators to
+identify the caged NFT. If a UTxO somehow contains multiple tokens,
+extraction fails and the validator rejects.
+
+| Shape | Test | Result |
+|---|---|---|
+| ADA + 1 NFT | `tokenFromValue_single_nft` | `Some(TokenId)` |
+| ADA only | `tokenFromValue_ada_only` | `None` |
+| 2 non-ADA policies | `tokenFromValue_multi_policy` | `None` |
+| 1 policy, 2 asset names | `tokenFromValue_multi_asset` | `None` |
+| Roundtrip via `valueFromToken` | `tokenFromValue_roundtrip` | `Some(TokenId)` |
+
+---
+
+## Summary
+
+| Category | Properties | Tests |
+|---|---|---|
+| Token uniqueness | 1 | 4 |
+| Minting integrity | 1 | 9 |
+| Ownership & authorization | 3 | 7 |
+| Token confinement | 1 | 2 |
+| Ownership transfer | 1 | 2 |
+| State integrity (MPF root) | 1 | 4 |
+| Proof consumption | 1 | 3 |
+| Request binding | 1 | 3 |
+| Datum-redeemer type safety | 4 | 4 |
+| Datum presence | 1 | 1 |
+| End / burn integrity | 1 | 2 |
+| Token extraction | 1 | 5 |
+| **Total** | **17** | **44** (242 checks) |

--- a/docs/architecture/types.md
+++ b/docs/architecture/types.md
@@ -1,7 +1,8 @@
 # Types & Encodings
 
-All on-chain data structures are defined in `types.ak` and
-compiled to Plutus V3 data encodings.
+All on-chain data structures are defined in
+[`types.ak`](https://github.com/cardano-foundation/mpfs/blob/main/on_chain/validators/types.ak)
+and compiled to Plutus V3 data encodings.
 
 ## Token Identity
 

--- a/docs/architecture/validators.md
+++ b/docs/architecture/validators.md
@@ -1,7 +1,10 @@
 # Validators
 
-The on-chain logic lives in a single script (`cage.ak`) that
-implements both a **minting policy** and a **spending validator**.
+The on-chain logic lives in a single script
+([`cage.ak`](https://github.com/cardano-foundation/mpfs/blob/main/on_chain/validators/cage.ak))
+that implements both a **minting policy** and a **spending validator**.
+Helper functions are in
+[`lib.ak`](https://github.com/cardano-foundation/mpfs/blob/main/on_chain/validators/lib.ak).
 
 ## Minting Policy (`mpfCage.mint`)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -45,7 +45,18 @@ just test
 
 ## How the Nix build works
 
-The flake pre-fetches the three Aiken dependencies (`stdlib`, `fuzz`,
-`merkle-patricia-forestry`) using `fetchFromGitHub` and populates
-`build/packages/` before running `aiken build`. This avoids network
-access inside the Nix sandbox.
+The flake pre-fetches the three Aiken dependencies
+([stdlib](https://github.com/aiken-lang/stdlib),
+[fuzz](https://github.com/aiken-lang/fuzz),
+[merkle-patricia-forestry](https://github.com/aiken-lang/merkle-patricia-forestry))
+using `fetchFromGitHub` and populates `build/packages/` before
+running `aiken build`. This avoids network access inside the Nix
+sandbox.
+
+## Upstream
+
+The validators originate from the
+[cardano-foundation/mpfs](https://github.com/cardano-foundation/mpfs)
+repository (`on_chain/` directory). See the upstream
+[documentation](https://cardano-foundation.github.io/mpfs/) for the
+full MPFS system including the off-chain TypeScript service.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,3 +15,4 @@ Modifications are verified on-chain via cryptographic proofs.
 - [Validators](architecture/validators.md) — minting policy and spending validator logic
 - [Types & Encodings](architecture/types.md) — datum, redeemer, and operation structures
 - [Proof System](architecture/proofs.md) — MPF proof format, verification, and performance
+- [Security Properties](architecture/properties.md) — 17 invariants verified by 44 tests

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,12 @@ Aiken validators for
 [Merkle Patricia Forestry](https://github.com/aiken-lang/merkle-patricia-forestry)
 on Cardano (Plutus V3).
 
+This repository contains the on-chain component of the
+[MPFS project](https://github.com/cardano-foundation/mpfs)
+by the Cardano Foundation. The validators were originally developed in
+[`on_chain/`](https://github.com/cardano-foundation/mpfs/tree/main/on_chain)
+of that repository.
+
 The on-chain component defines a **cage** pattern: an NFT locked at
 a script address carries the current MPF root hash as its datum.
 Modifications are verified on-chain via cryptographic proofs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,3 +47,4 @@ nav:
       - Validators: architecture/validators.md
       - Types & Encodings: architecture/types.md
       - Proof System: architecture/proofs.md
+      - Security Properties: architecture/properties.md

--- a/validators/cage.ak
+++ b/validators/cage.ak
@@ -96,8 +96,10 @@ use aiken/collection/list.{find, foldl, has, head}
 use aiken/merkle_patricia_forestry.{MerklePatriciaForestry, Proof, empty, root}
 use aiken/merkle_patricia_forestry as mpf
 use aiken/option.{is_some}
+use aiken/fuzz
 use cardano/address.{from_script}
-use cardano/assets.{PolicyId, from_lovelace, zero}
+use cardano/address
+use cardano/assets.{PolicyId, from_asset, from_lovelace, zero}
 use cardano/transaction.{
   InlineDatum, Input, NoDatum, Output, OutputReference, Transaction, find_input,
 }
@@ -903,6 +905,566 @@ test canMint() {
       outputs: [minted],
       mint: minted_value,
       inputs: [Input { output_reference: reference, output: consumed_utxo }],
+    },
+  )
+}
+
+// ============================================================================
+// Minting failure tests
+// ============================================================================
+
+// Helper: valid mint transaction (reusable base for failure tests)
+fn mint_tx() -> Transaction {
+  Transaction {
+    ..transaction.placeholder,
+    outputs: [minted],
+    mint: minted_value,
+    inputs: [Input { output_reference: reference, output: consumed_utxo }],
+  }
+}
+
+test mint_missing_input() fail {
+  mpfCage.mint(
+    Minting(minting),
+    "policy_id",
+    Transaction { ..mint_tx(), inputs: [] },
+  )
+}
+
+test mint_quantity_two() fail {
+  mpfCage.mint(
+    Minting(minting),
+    "policy_id",
+    Transaction {
+      ..mint_tx(),
+      mint: from_asset("policy_id", assetName(reference), 2),
+    },
+  )
+}
+
+test mint_to_wallet() fail {
+  let wallet_output =
+    Output { ..minted, address: address.from_verification_key("someone") }
+  mpfCage.mint(
+    Minting(minting),
+    "policy_id",
+    Transaction { ..mint_tx(), outputs: [wallet_output] },
+  )
+}
+
+test mint_to_wrong_script() fail {
+  let wrong_output =
+    Output { ..minted, address: address.from_script("other_script") }
+  mpfCage.mint(
+    Minting(minting),
+    "policy_id",
+    Transaction { ..mint_tx(), outputs: [wrong_output] },
+  )
+}
+
+test mint_nonempty_root() fail {
+  let bad_output =
+    Output {
+      ..minted,
+      datum: InlineDatum(
+        StateDatum(State { owner: "owner", root: "nonempty_root" }),
+      ),
+    }
+  mpfCage.mint(
+    Minting(minting),
+    "policy_id",
+    Transaction { ..mint_tx(), outputs: [bad_output] },
+  )
+}
+
+test mint_request_datum() fail {
+  let bad_output =
+    Output {
+      ..minted,
+      datum: InlineDatum(
+        RequestDatum(
+          Request {
+            requestToken: token,
+            requestKey: "k",
+            requestValue: Insert("v"),
+            requestOwner: "owner",
+          },
+        ),
+      ),
+    }
+  mpfCage.mint(
+    Minting(minting),
+    "policy_id",
+    Transaction { ..mint_tx(), outputs: [bad_output] },
+  )
+}
+
+test mint_no_datum() fail {
+  let bad_output = Output { ..minted, datum: NoDatum }
+  mpfCage.mint(
+    Minting(minting),
+    "policy_id",
+    Transaction { ..mint_tx(), outputs: [bad_output] },
+  )
+}
+
+// ============================================================================
+// Retract tests
+// ============================================================================
+
+test retract_happy() {
+  mpfCage.spend(
+    Some(aRequest),
+    Retract,
+    testRequestRef,
+    Transaction {
+      ..transaction.placeholder,
+      extra_signatories: ["owner"],
+    },
+  )
+}
+
+test retract_wrong_signer() fail {
+  mpfCage.spend(
+    Some(aRequest),
+    Retract,
+    testRequestRef,
+    Transaction {
+      ..transaction.placeholder,
+      extra_signatories: ["someone_else"],
+    },
+  )
+}
+
+// ============================================================================
+// Contribute tests
+// ============================================================================
+
+test contribute_wrong_token() fail {
+  let wrong_request =
+    RequestDatum(
+      Request {
+        requestToken: TokenId { assetName: "different_asset" },
+        requestKey: "42",
+        requestValue: Insert("42"),
+        requestOwner: "owner",
+      },
+    )
+  mpfCage.spend(
+    Some(wrong_request),
+    Contribute(testStateRef),
+    testRequestRef,
+    Transaction { ..transaction.placeholder, inputs: [update, request] },
+  )
+}
+
+test contribute_missing_ref() fail {
+  let missing_ref =
+    OutputReference { transaction_id: "nonexistent", output_index: 0 }
+  mpfCage.spend(
+    Some(aRequest),
+    Contribute(missing_ref),
+    testRequestRef,
+    Transaction { ..transaction.placeholder, inputs: [update, request] },
+  )
+}
+
+// ============================================================================
+// Modify tests
+// ============================================================================
+
+test modify_missing_signature() fail {
+  mpfCage.spend(
+    stateDatum,
+    Modify([[]]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      outputs: [output],
+      extra_signatories: [],
+      inputs: [update, request],
+    },
+  )
+}
+
+test modify_wrong_address() fail {
+  let bad_output =
+    Output {
+      ..output,
+      address: address.from_script("different_script"),
+    }
+  mpfCage.spend(
+    stateDatum,
+    Modify([[]]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      outputs: [bad_output],
+      extra_signatories: ["owner"],
+      inputs: [update, request],
+    },
+  )
+}
+
+test modify_owner_transfer() {
+  // output already has owner: "new-owner", this should succeed
+  mpfCage.spend(
+    stateDatum,
+    Modify([[]]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      outputs: [output],
+      extra_signatories: ["owner"],
+      inputs: [update, request],
+    },
+  )
+}
+
+test modify_no_requests() {
+  // No request inputs -> root stays the same (empty MPF root)
+  let unchanged_output =
+    Output {
+      address: testScriptAddress,
+      value: testValue,
+      datum: InlineDatum(
+        StateDatum(State { owner: "owner", root: root(empty) }),
+      ),
+      reference_script: None,
+    }
+  mpfCage.spend(
+    stateDatum,
+    Modify([]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      outputs: [unchanged_output],
+      extra_signatories: ["owner"],
+      inputs: [update],
+    },
+  )
+}
+
+test modify_skip_other_token() {
+  // Request for a different token — should be skipped, no proof consumed
+  let other_request_datum =
+    RequestDatum(
+      Request {
+        requestToken: TokenId { assetName: "other_token" },
+        requestKey: "42",
+        requestValue: Insert("42"),
+        requestOwner: "someone",
+      },
+    )
+  let other_request =
+    Input {
+      output_reference: OutputReference {
+        transaction_id: "3334567890abcdef",
+        output_index: 1,
+      },
+      output: Output {
+        address: testScriptAddress,
+        value: from_lovelace(0),
+        datum: InlineDatum(other_request_datum),
+        reference_script: None,
+      },
+    }
+  let unchanged_output =
+    Output {
+      address: testScriptAddress,
+      value: testValue,
+      datum: InlineDatum(
+        StateDatum(State { owner: "owner", root: root(empty) }),
+      ),
+      reference_script: None,
+    }
+  mpfCage.spend(
+    stateDatum,
+    Modify([]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      outputs: [unchanged_output],
+      extra_signatories: ["owner"],
+      inputs: [update, other_request],
+    },
+  )
+}
+
+test modify_too_few_proofs() fail {
+  // One matching request but zero proofs
+  mpfCage.spend(
+    stateDatum,
+    Modify([]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      outputs: [output],
+      extra_signatories: ["owner"],
+      inputs: [update, request],
+    },
+  )
+}
+
+test modify_extra_proofs() {
+  // One matching request, two proofs — extra proof is ignored
+  mpfCage.spend(
+    stateDatum,
+    Modify([[], []]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      outputs: [output],
+      extra_signatories: ["owner"],
+      inputs: [update, request],
+    },
+  )
+}
+
+test modify_wrong_root() fail {
+  let bad_root_output =
+    Output {
+      address: testScriptAddress,
+      value: testValue,
+      datum: InlineDatum(
+        StateDatum(State { owner: "new-owner", root: "wrong_root_hash" }),
+      ),
+      reference_script: None,
+    }
+  mpfCage.spend(
+    stateDatum,
+    Modify([[]]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      outputs: [bad_root_output],
+      extra_signatories: ["owner"],
+      inputs: [update, request],
+    },
+  )
+}
+
+// ============================================================================
+// End tests
+// ============================================================================
+
+// End needs: owner signs + mint field contains the token being burned
+const burn_value = valueFromToken("policy_id", testToken)
+
+test end_happy() {
+  mpfCage.spend(
+    stateDatum,
+    End,
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      extra_signatories: ["owner"],
+      inputs: [update],
+      mint: burn_value,
+    },
+  )
+}
+
+test end_missing_signature() fail {
+  mpfCage.spend(
+    stateDatum,
+    End,
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      extra_signatories: [],
+      inputs: [update],
+      mint: burn_value,
+    },
+  )
+}
+
+test end_wrong_token_in_mint() fail {
+  let wrong_burn = valueFromToken("policy_id", TokenId { assetName: "wrong" })
+  mpfCage.spend(
+    stateDatum,
+    End,
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      extra_signatories: ["owner"],
+      inputs: [update],
+      mint: wrong_burn,
+    },
+  )
+}
+
+// ============================================================================
+// Datum-redeemer mismatch tests
+// ============================================================================
+
+test retract_on_state_datum() fail {
+  mpfCage.spend(
+    stateDatum,
+    Retract,
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      extra_signatories: ["owner"],
+    },
+  )
+}
+
+test contribute_on_state_datum() fail {
+  mpfCage.spend(
+    stateDatum,
+    Contribute(testStateRef),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      inputs: [update],
+    },
+  )
+}
+
+test modify_on_request_datum() fail {
+  mpfCage.spend(
+    Some(aRequest),
+    Modify([]),
+    testRequestRef,
+    Transaction {
+      ..transaction.placeholder,
+      extra_signatories: ["owner"],
+      inputs: [request],
+    },
+  )
+}
+
+test end_on_request_datum() fail {
+  mpfCage.spend(
+    Some(aRequest),
+    End,
+    testRequestRef,
+    Transaction {
+      ..transaction.placeholder,
+      extra_signatories: ["owner"],
+      inputs: [request],
+      mint: burn_value,
+    },
+  )
+}
+
+// ============================================================================
+// Edge cases
+// ============================================================================
+
+test spend_no_datum() fail {
+  mpfCage.spend(
+    None,
+    Retract,
+    testRequestRef,
+    transaction.placeholder,
+  )
+}
+
+// ============================================================================
+// Property tests
+// ============================================================================
+
+fn owner_fuzzer() -> Fuzzer<ByteArray> {
+  fuzz.bytearray_fixed(28)
+}
+
+test prop_retract_requires_owner(
+  signer via owner_fuzzer(),
+) fail once {
+  let req =
+    RequestDatum(
+      Request {
+        requestToken: testToken,
+        requestKey: "k",
+        requestValue: Insert("v"),
+        requestOwner: "the_real_owner_key_aaaaaaaaaa",
+      },
+    )
+  mpfCage.spend(
+    Some(req),
+    Retract,
+    testRequestRef,
+    Transaction {
+      ..transaction.placeholder,
+      extra_signatories: [signer],
+    },
+  )
+}
+
+test prop_modify_requires_owner(
+  signer via owner_fuzzer(),
+) fail once {
+  let s = State { owner: "the_real_owner_key_aaaaaaaaaa", root: root(empty) }
+  let unchanged_output =
+    Output {
+      address: testScriptAddress,
+      value: testValue,
+      datum: InlineDatum(
+        StateDatum(State { owner: "the_real_owner_key_aaaaaaaaaa", root: root(empty) }),
+      ),
+      reference_script: None,
+    }
+  let state_input =
+    Input {
+      output_reference: testStateRef,
+      output: Output {
+        address: testScriptAddress,
+        value: testValue,
+        datum: InlineDatum(Some(StateDatum(s))),
+        reference_script: None,
+      },
+    }
+  mpfCage.spend(
+    Some(StateDatum(s)),
+    Modify([]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      outputs: [unchanged_output],
+      extra_signatories: [signer],
+      inputs: [state_input],
+    },
+  )
+}
+
+test prop_mint_roundtrip(
+  params via fuzz.tuple(
+    fuzz.bytearray_fixed(32),
+    fuzz.int_between(0, 255),
+  ),
+) {
+  let (tx_id, idx) = params
+  let ref = OutputReference { transaction_id: tx_id, output_index: idx }
+  let tok = TokenId { assetName: assetName(ref) }
+  let mint_redeemer = Mint { asset: ref }
+  let val = valueFromToken("policy_id", tok)
+  let addr = address.from_script("policy_id")
+  let out =
+    Output {
+      address: addr,
+      value: val,
+      datum: InlineDatum(
+        StateDatum(State { owner: "owner", root: root(empty) }),
+      ),
+      reference_script: None,
+    }
+  let utxo =
+    Output {
+      address: paying_address,
+      value: zero,
+      datum: NoDatum,
+      reference_script: None,
+    }
+  mpfCage.mint(
+    Minting(mint_redeemer),
+    "policy_id",
+    Transaction {
+      ..transaction.placeholder,
+      outputs: [out],
+      mint: val,
+      inputs: [Input { output_reference: ref, output: utxo }],
     },
   )
 }

--- a/validators/lib.ak
+++ b/validators/lib.ak
@@ -44,7 +44,9 @@ use aiken/collection/dict.{get, keys}
 use aiken/collection/list.{delete, find}
 use aiken/crypto.{Hash, Sha2_256, sha2_256}
 use aiken/primitive/bytearray.{concat, from_int_big_endian}
+use aiken/fuzz
 use cardano/assets.{AssetName, PolicyId, Value, from_asset, policies, tokens}
+use cardano/assets
 use cardano/transaction.{Input, Output, OutputReference}
 
 /// A unique identifier for a token, consisting of just the asset name.
@@ -237,4 +239,99 @@ pub fn extractTokenFromInputs(what: OutputReference, inputs: List<Input>) {
       }
     _ -> None
   }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+// --- assetName tests ---
+
+const ref_a =
+  OutputReference { transaction_id: "tx_aaaaaa", output_index: 0 }
+
+const ref_b =
+  OutputReference { transaction_id: "tx_bbbbbb", output_index: 0 }
+
+const ref_c =
+  OutputReference { transaction_id: "tx_aaaaaa", output_index: 1 }
+
+test assetName_deterministic() {
+  assetName(ref_a) == assetName(ref_a)
+}
+
+test assetName_different_txid() {
+  assetName(ref_a) != assetName(ref_b)
+}
+
+test assetName_different_index() {
+  assetName(ref_a) != assetName(ref_c)
+}
+
+test prop_assetName_deterministic(
+  params via fuzz.tuple(
+    fuzz.bytearray_fixed(32),
+    fuzz.int_between(0, 65535),
+  ),
+) {
+  let (tx_id, idx) = params
+  let ref = OutputReference { transaction_id: tx_id, output_index: idx }
+  assetName(ref) == assetName(ref)
+}
+
+// --- tokenFromValue tests ---
+
+const test_policy = "test_policy_id"
+
+const test_asset = "test_asset_name"
+
+test tokenFromValue_single_nft() {
+  let v = from_asset(test_policy, test_asset, 1)
+  tokenFromValue(v) == Some(TokenId { assetName: test_asset })
+}
+
+test tokenFromValue_ada_only() {
+  let v = from_asset("", "", 2_000_000)
+  tokenFromValue(v) == None
+}
+
+test tokenFromValue_multi_policy() {
+  let v =
+    from_asset("policy_a", "asset", 1)
+      |> assets.merge(from_asset("policy_b", "asset", 1))
+  tokenFromValue(v) == None
+}
+
+test tokenFromValue_multi_asset() {
+  let v =
+    from_asset(test_policy, "asset_a", 1)
+      |> assets.merge(from_asset(test_policy, "asset_b", 1))
+  tokenFromValue(v) == None
+}
+
+test tokenFromValue_roundtrip() {
+  let pid = "my_policy"
+  let tid = TokenId { assetName: "my_asset" }
+  tokenFromValue(valueFromToken(pid, tid)) == Some(tid)
+}
+
+// --- quantity tests ---
+
+const q_policy = "q_policy"
+
+const q_token = TokenId { assetName: "q_asset" }
+
+test quantity_present() {
+  let v = from_asset(q_policy, "q_asset", 1)
+  quantity(q_policy, v, q_token) == Some(1)
+}
+
+test quantity_wrong_policy() {
+  let v = from_asset("other_policy", "q_asset", 1)
+  quantity(q_policy, v, q_token) == None
+}
+
+test quantity_wrong_asset() {
+  let v = from_asset(q_policy, "other_asset", 1)
+  quantity(q_policy, v, q_token) == None
 }


### PR DESCRIPTION
## Summary

- Add 42 new inline tests (44 total, 242 checks) covering all validator paths: minting failures, spending redeemers (Modify/End/Contribute/Retract), datum-redeemer type safety, edge cases, and 3 property tests using `aiken-lang/fuzz`
- Add security properties documentation (`docs/architecture/properties.md`) with 17 invariants across 12 categories, cross-referenced with tests and upstream [MPFS specification](https://cardano-foundation.github.io/mpfs/)
- Link all documentation pages to upstream [cardano-foundation/mpfs](https://github.com/cardano-foundation/mpfs) source files and Aiken dependency repos

## Test plan

- [x] `aiken check` passes: 44 tests, 242 checks, 0 errors