### PR TITLE
fix: correct documentation errors found during review

### DIFF
--- a/docs/architecture/types.md
+++ b/docs/architecture/types.md
@@ -7,8 +7,15 @@ and compiled to Plutus V3 data encodings.
 ## Token Identity
 
 ```aiken
-type TokenId = (PolicyId, AssetName)
+type TokenId {
+    assetName: AssetName
+}
 ```
+
+`TokenId` wraps only the `AssetName`. The `PolicyId` is always
+the cage script's own hash (since the minting policy and spending
+validator share the same script) and is passed separately where
+needed.
 
 The `AssetName` is derived from a consumed UTxO reference via
 SHA2-256, guaranteeing global uniqueness.
@@ -55,7 +62,7 @@ type Request {
 
 | Field | Encoding | Description |
 |---|---|---|
-| `requestToken` | `(PolicyId, AssetName)` | Target MPF token |
+| `requestToken` | `TokenId` | Target MPF token (asset name only; policy ID is implicit) |
 | `requestOwner` | 28 bytes | Who can retract this request |
 | `requestKey` | variable | Key in the MPF trie |
 | `requestValue` | `Operation` | What to do with this key |
@@ -135,10 +142,10 @@ Constr(1,           -- CageDatum.StateDatum
 ```
 Constr(0,           -- CageDatum.RequestDatum
   [ Constr(0,       -- Request
-      [ Constr(0, [Bytes(policy_id), Bytes(asset_name)])  -- TokenId
+      [ Constr(0, [Bytes(asset_name)])  -- TokenId
       , Bytes(owner_pkh)
       , Bytes(key)
-      , Constr(0, [Bytes(new_value)])                     -- Insert
+      , Constr(0, [Bytes(new_value)])   -- Insert
       ])
   ])
 ```


### PR DESCRIPTION
## Summary

Fixes 13 documentation errors found by cross-referencing docs against source code.

- **types.md**: `TokenId` is a record `{ assetName: AssetName }`, not a `(PolicyId, AssetName)` tuple. Fix Plutus encoding example
- **proofs.md**: Replace private `including`/`excluding` functions with actual public API (`mpf.insert`/`delete`/`update`). Remove unverifiable hashing internals and performance table
- **validators.md**: Fix MPF function signatures to include `root` parameter. Fix helper signatures (`quantity` returns `Option<Int>`, `tokenFromValue` returns `Option<TokenId>`). Add `Contribute` redeemer to Modify diagram. Fix mint rule 5 (owner is unrestricted, not set to signer)
- **overview.md**: Replace confusing `architecture-beta` diagram with clear role-based graph (oracle/requester/observer). Rewrite protocol flow with concrete keys/values. Expand security properties (5 to 7). Replace stale toml block with linked dependency table including `fuzz`

## Test plan

- [x] Docs build with `mkdocs build`
- [x] Verify diagrams render correctly on GitHub Pages