### PR TITLE
feat: time-gated request phases and Reject redeemer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,24 @@ jobs:
           name: plutus-json
           path: result
 
+  typecheck:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: e2e
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - run: npm ci
+
+      - run: npx tsc --noEmit
+
   e2e:
     needs: build
     runs-on: ubuntu-latest

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -24,19 +24,20 @@ graph TD
     B["Requester B"]
     Obs["Observer"]
 
-    O -->|"Boot / Modify / End"| V
+    O -->|"Boot / Modify / Reject / End"| V
     A -->|"Submit request"| R1
-    B -->|"Submit request"| R1
-    R1 -->|"consumed by Modify"| S1
+    B -->|"Submit / Retract request"| R1
+    R1 -->|"consumed by Modify or Reject"| S1
     Obs -.->|"read chain history"| Blockchain
 ```
 
 The **oracle** (token owner) controls the MPF token: it boots
-the token, applies pending requests via `Modify`, and can
-destroy it with `End`. **Requesters** submit modification
-requests as UTxOs at the script address. **Observers** read
-the MPF state from the blockchain history — no on-chain
-interaction is needed.
+the token, applies pending requests via `Modify`, rejects
+expired or dishonest requests via `Reject`, and can destroy
+it with `End`. **Requesters** submit modification requests as
+UTxOs at the script address and can retract them during Phase 2.
+**Observers** read the MPF state from the blockchain history —
+no on-chain interaction is needed.
 
 ## Transaction Lifecycle
 
@@ -47,26 +48,58 @@ when the oracle processes a `Modify` transaction.
 stateDiagram-v2
     state "Token Lifecycle" as TL {
         [*] --> Active: Boot (Mint)
-        Active --> Active: Modify
+        Active --> Active: Modify / Reject
+        Active --> Active: Migrate (new validator)
         Active --> [*]: End (Burn)
     }
 
     state "Request Lifecycle" as RL {
-        [*] --> Pending: Submit (pay to script)
-        Pending --> Consumed: Contribute + Modify
-        Pending --> [*]: Retract
+        [*] --> Phase1: Submit (pay to script)
+        Phase1 --> Consumed: Contribute + Modify
+        Phase1 --> Phase2: process_time elapsed
+        Phase2 --> [*]: Retract
+        Phase2 --> Phase3: retract_time elapsed
+        Phase3 --> Rejected: Reject (refund minus fee)
     }
-
-    Pending --> Active: consumed by
 ```
 
-| Transaction | Action | Validator |
-|---|---|---|
-| Boot | Mint a new MPF token with empty root | Minting policy |
-| Submit | Lock ADA at script with a modification request | — (pay to script, no validator) |
-| Modify | Oracle applies pending requests, updates MPF root | Spending validator (Modify on state + Contribute on each request) |
-| Retract | Request owner cancels a pending request, reclaims ADA | Spending validator (Retract) |
-| End | Burn the MPF token, destroy the instance | Minting policy (Burning) + Spending validator (End) |
+### Time-Gated Phases
+
+Each request passes through three exclusive time phases,
+enforced on-chain via `tx.validity_range`. The phase boundaries
+are determined by the request's `submitted_at` timestamp and the
+validator's immutable `process_time` and `retract_time` parameters.
+
+```mermaid
+gantt
+    title Request Time Phases
+    dateFormat X
+    axisFormat %s
+
+    section Phases
+    Phase 1 - Oracle Modify   :active, p1, 0, 10
+    Phase 2 - Requester Retract :crit, p2, 10, 20
+    Phase 3 - Oracle Reject    :done, p3, 20, 30
+```
+
+| Phase | Window | Allowed Operations | Actor |
+|---|---|---|---|
+| Phase 1 | `[submitted_at, submitted_at + process_time)` | Modify, Contribute | Oracle |
+| Phase 2 | `[submitted_at + process_time, submitted_at + process_time + retract_time)` | Retract | Requester |
+| Phase 3 | `[submitted_at + process_time + retract_time, ...)` | Reject | Oracle |
+
+A request with a **dishonest `submitted_at`** (in the future) is
+immediately rejectable by the oracle, regardless of phase.
+
+| Transaction | Action | Validator | Phase |
+|---|---|---|---|
+| Boot | Mint a new MPF token with empty root | Minting policy | — |
+| Submit | Lock ADA at script with a modification request | — (pay to script, no validator) | — |
+| Modify | Oracle applies pending requests, updates MPF root | Spending validator (Modify on state + Contribute on each request) | 1 |
+| Retract | Request owner cancels a pending request, reclaims ADA | Spending validator (Retract) | 2 |
+| Reject | Oracle discards expired/dishonest requests, refunds ADA minus fee | Spending validator (Reject on state + Contribute on each request) | 3 |
+| Migrate | Move token to a new validator version | Minting policy (Burning old + Migrating new) + Spending validator (End) | — |
+| End | Burn the MPF token, destroy the instance | Minting policy (Burning) + Spending validator (End) | — |
 
 ## Protocol Flow
 
@@ -84,16 +117,31 @@ sequenceDiagram
     C->>B: Submit Request: Insert("keyB", "valB")
     Note over B: Two Request UTxOs at script address
 
-    O->>B: Modify Token X (consumes both requests)
-    Note over B: Root updated: empty → root(keyA, keyB)
+    rect rgb(40, 80, 40)
+        Note over O,B: Phase 1 — Oracle processes requests
+        O->>B: Modify Token X (consumes both requests)
+        Note over B: Root updated: empty → root(keyA, keyB)
+    end
 
     A->>B: Submit Request: Delete("keyB", "valB")
-    O->>B: Modify Token X
-    Note over B: Root updated: root(keyA, keyB) → root(keyA)
+    rect rgb(40, 80, 40)
+        Note over O,B: Phase 1
+        O->>B: Modify Token X
+        Note over B: Root updated: root(keyA, keyB) → root(keyA)
+    end
 
     C->>B: Submit Request: Delete("keyA", "valA")
-    C->>B: Retract own request
-    Note over B: Request UTxO reclaimed, root unchanged
+    rect rgb(80, 80, 40)
+        Note over C,B: Phase 2 — Requester retracts
+        C->>B: Retract own request
+        Note over B: Request UTxO reclaimed, root unchanged
+    end
+
+    A->>B: Submit Request: Insert("spam", "data")
+    rect rgb(80, 40, 40)
+        Note over O,B: Phase 3 — Oracle rejects expired request
+        O->>B: Reject (refund ADA minus fee, root unchanged)
+    end
 
     O->>B: End Token X (Burn)
     Note over B: Token destroyed
@@ -101,21 +149,27 @@ sequenceDiagram
 
 ## Security Properties
 
-The validators enforce 17 invariants across 12 categories, each
-verified by the inline test suite (44 tests / 242 checks):
+The validators enforce invariants across 16 categories, each
+verified by the inline test suite (67 tests):
 
-1. **Ownership** — only the oracle (token owner) can modify or destroy a token.
+1. **Ownership** — only the oracle (token owner) can modify, reject, or destroy a token.
 2. **Integrity** — every MPF modification carries a cryptographic proof
    verified on-chain; the output root must match the proof computation.
 3. **Uniqueness** — token IDs are derived from spent UTxOs, guaranteed
    unique by the ledger.
 4. **Confinement** — the token must remain at the script address after
    every operation.
-5. **Retractability** — request owners can always reclaim their locked ADA.
+5. **Retractability** — request owners can reclaim their locked ADA during Phase 2.
 6. **Request binding** — a request's target token is validated on-chain
    before it can be consumed.
 7. **Type safety** — each redeemer/datum combination is enforced; mismatches
    are rejected.
+8. **Time-gated phases** — each request passes through three exclusive phases
+   (oracle Modify, requester Retract, oracle Reject), preventing race conditions.
+9. **DDoS protection** — expired or dishonest requests can be rejected by the
+   oracle, who keeps the fee and refunds the rest.
+10. **Fee enforcement** — oracle fees are validated on-chain; requesters are
+    refunded correctly.
 
 See [Security Properties](properties.md) for the complete list with
 test cross-references.

--- a/docs/architecture/validators.md
+++ b/docs/architecture/validators.md
@@ -1,14 +1,35 @@
 # Validators
 
 The on-chain logic lives in a single script
-([`cage.ak`](https://github.com/cardano-foundation/mpfs/blob/main/on_chain/validators/cage.ak))
+([`cage.ak`](https://github.com/cardano-foundation/cardano-mpfs-onchain/blob/main/validators/cage.ak))
 that implements both a **minting policy** and a **spending validator**.
 Helper functions are in
-[`lib.ak`](https://github.com/cardano-foundation/mpfs/blob/main/on_chain/validators/lib.ak).
+[`lib.ak`](https://github.com/cardano-foundation/cardano-mpfs-onchain/blob/main/validators/lib.ak).
+
+## Validator Parameters
+
+The cage validator is parameterized by three immutable values,
+set at deployment time:
+
+```aiken
+validator mpfCage(_version: Int, process_time: Int, retract_time: Int) {
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `_version` | `Int` | Version tag (enables migration between validator versions) |
+| `process_time` | `Int` | Duration (ms) of Phase 1 — oracle-exclusive processing window |
+| `retract_time` | `Int` | Duration (ms) of Phase 2 — requester-exclusive retract window |
+
+Different parameter values produce different script hashes and
+addresses. The parameters are baked into the compiled script, so
+they cannot be changed after deployment.
+
+---
 
 ## Minting Policy (`mpfCage.mint`)
 
-Controls creation and destruction of MPF tokens.
+Controls creation, migration, and destruction of MPF tokens.
 
 ### Boot (Minting)
 
@@ -36,6 +57,29 @@ graph LR
     TX -->|produces| STATE
 ```
 
+### Migration (Migrating)
+
+Mints a token under the new validator by carrying over the identity
+and root from an old validator version.
+
+**Validation rules:**
+
+1. The old token (under `oldPolicy`) is burned (-1) in the same
+   transaction.
+2. Exactly one new token is minted.
+3. The token is sent to the new validator's script address.
+4. The output carries a `StateDatum` (root may be non-empty).
+
+```mermaid
+graph LR
+    OLD["Old State UTxO<br/>(old validator)"]
+    TX["Migration Transaction"]
+    NEW["New State UTxO<br/>(new validator, same root)"]
+
+    OLD -->|"End + Burn old"| TX
+    TX -->|"Mint new + Migrate"| NEW
+```
+
 ### Burning
 
 Burns the MPF token when the instance is destroyed. No additional
@@ -45,23 +89,28 @@ validation beyond the spending validator's `End` redeemer.
 
 ## Spending Validator (`mpfCage.spend`)
 
-Handles four operations on UTxOs locked at the script address.
+Handles five operations on UTxOs locked at the script address.
 
 ### Modify (ConStr2)
 
 The token owner applies pending requests to the MPF trie.
+Only allowed during **Phase 1** of each request.
 
 **Redeemer:** `Modify(List<Proof>)` — one proof per consumed request.
 
 **Validation rules:**
 
 - Owner must sign the transaction.
+- The transaction validity range must be entirely within Phase 1
+  for every consumed request (`tx valid before submitted_at + process_time`).
+- Each request's `fee` must equal `state.max_fee`.
 - All consumed request UTxOs reference the correct token.
 - Each request is paired with a valid MPF proof.
 - The proofs are folded left-to-right over the current root to
   compute the new root.
 - The output datum's root must equal the computed new root.
 - The token remains at the script address.
+- Each requester receives a refund of `lovelace - fee`.
 
 ```mermaid
 graph TD
@@ -88,9 +137,10 @@ appropriate MPF function based on the operation type:
 
 ### Contribute (ConStr1)
 
-Spends a request UTxO during an update. Used together with
-`Modify` in the same transaction — the state UTxO uses `Modify`,
-while each request UTxO uses `Contribute`.
+Spends a request UTxO during an update or reject. Used together
+with `Modify` or `Reject` in the same transaction — the state
+UTxO uses `Modify`/`Reject`, while each request UTxO uses
+`Contribute`.
 
 **Redeemer:** `Contribute(OutputReference)` — points to the
 state UTxO being updated.
@@ -99,15 +149,54 @@ state UTxO being updated.
 
 - The referenced state UTxO is consumed in the same transaction.
 - The request's `requestToken` matches the state's token.
+- The request must be in **Phase 1** (for Modify) or **rejectable**
+  (Phase 3 or dishonest `submitted_at`). Phase 2 is blocked to
+  protect the requester's exclusive retract window.
 
 ### Retract (ConStr3)
 
 Allows a request owner to cancel a pending request and reclaim
-their locked ADA.
+their locked ADA. Only allowed during **Phase 2**.
 
 **Validation rules:**
 
 - The request owner must sign the transaction.
+- The transaction validity range must be entirely within Phase 2
+  (`tx valid after submitted_at + process_time - 1` and
+  `tx valid before submitted_at + process_time + retract_time`).
+
+### Reject (ConStr4)
+
+Allows the oracle to discard expired or dishonest requests.
+The oracle keeps the fee and refunds the remaining lovelace
+to each requester. The MPF root must **not** change.
+
+**Redeemer:** `Reject` — applied to the state UTxO. Each request
+UTxO uses `Contribute`.
+
+**Validation rules:**
+
+- Owner must sign the transaction.
+- Each request must be **rejectable**: either in Phase 3
+  (`tx valid after submitted_at + process_time + retract_time - 1`)
+  or have a dishonest `submitted_at` (in the future).
+- The output root must equal the input root (no MPF changes).
+- The token remains at the script address.
+- Each requester receives a refund of `lovelace - fee`.
+
+```mermaid
+graph TD
+    STATE_IN["State UTxO<br/>(root R)<br/>redeemer: Reject"]
+    REQ1["Expired Request 1<br/>redeemer: Contribute(stateRef)"]
+    REQ2["Expired Request 2<br/>redeemer: Contribute(stateRef)"]
+    STATE_OUT["State UTxO<br/>(root R unchanged)"]
+    REF1["Refund 1<br/>lovelace - fee"]
+    REF2["Refund 2<br/>lovelace - fee"]
+
+    STATE_IN --> STATE_OUT
+    REQ1 --> REF1
+    REQ2 --> REF2
+```
 
 ### End (ConStr0)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,8 @@ of that repository.
 The on-chain component defines a **cage** pattern: an NFT locked at
 a script address carries the current MPF root hash as its datum.
 Modifications are verified on-chain via cryptographic proofs.
+Time-gated phases prevent race conditions between the oracle and
+requesters, and a Reject mechanism enables DDoS protection.
 
 ## Documentation
 
@@ -21,4 +23,4 @@ Modifications are verified on-chain via cryptographic proofs.
 - [Validators](architecture/validators.md) — minting policy and spending validator logic
 - [Types & Encodings](architecture/types.md) — datum, redeemer, and operation structures
 - [Proof System](architecture/proofs.md) — MPF proof format, verification, and performance
-- [Security Properties](architecture/properties.md) — 17 invariants verified by 44 tests
+- [Security Properties](architecture/properties.md) — 16 categories verified by 67 tests

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,6 +9,7 @@
         "@lucid-evolution/lucid": "^0.4.29"
       },
       "devDependencies": {
+        "@types/node": "^25.2.3",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
       }
@@ -1538,6 +1539,17 @@
       "resolved": "https://registry.npmjs.org/@types/json-bigint/-/json-bigint-1.0.4.tgz",
       "integrity": "sha512-ydHooXLbOmxBbubnA7Eh+RpBzuaIiQjh8WGJYQB50JFGFrdxW7JzVlyEV7fAXw0T2sqJ1ysTneJbiyNLqZRAag==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
@@ -6214,6 +6226,13 @@
       "dependencies": {
         "multiformats": "^13.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utf8-codec": {
       "version": "1.0.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,6 +9,7 @@
     "@lucid-evolution/lucid": "^0.4.29"
   },
   "devDependencies": {
+    "@types/node": "^25.2.3",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"
   }

--- a/e2e/src/blueprint.ts
+++ b/e2e/src/blueprint.ts
@@ -16,7 +16,11 @@ interface Blueprint {
   }>;
 }
 
-export function loadValidator(version: number) {
+export function loadValidator(
+  version: number,
+  processTime: bigint = 60_000n,
+  retractTime: bigint = 60_000n,
+) {
   const path = process.env.PLUTUS_JSON ?? "/app/plutus.json";
   const raw = readFileSync(path, "utf-8");
   const blueprint: Blueprint = JSON.parse(raw);
@@ -32,12 +36,9 @@ export function loadValidator(version: number) {
     throw new Error("Validator not found in plutus.json");
   }
 
-  const mintScript = applyParamsToScript(mintEntry.compiledCode, [
-    BigInt(version),
-  ]);
-  const spendScript = applyParamsToScript(spendEntry.compiledCode, [
-    BigInt(version),
-  ]);
+  const params = [BigInt(version), processTime, retractTime];
+  const mintScript = applyParamsToScript(mintEntry.compiledCode, params);
+  const spendScript = applyParamsToScript(spendEntry.compiledCode, params);
 
   const mintPolicy: MintingPolicy = {
     type: "PlutusV3",
@@ -57,5 +58,7 @@ export function loadValidator(version: number) {
     spendValidator,
     policyId,
     scriptAddress,
+    processTime,
+    retractTime,
   };
 }

--- a/e2e/src/codec.ts
+++ b/e2e/src/codec.ts
@@ -37,7 +37,7 @@ export function encodeBurningRedeemer(): string {
   return Data.to(new Constr(2, []));
 }
 
-// UpdateRedeemer = End(0) | Contribute(OutputReference)(1) | Modify(List<Proof>)(2) | Retract(3)
+// UpdateRedeemer = End(0) | Contribute(OutputReference)(1) | Modify(List<Proof>)(2) | Retract(3) | Reject(4)
 
 // End is index 0
 export function encodeEndRedeemer(): string {
@@ -56,7 +56,7 @@ export function encodeContributeRedeemer(stateUtxo: UTxO): string {
 // Modify is index 2, takes List<Proof> where Proof = List<ProofStep>
 // For inserting into an empty MPF, proof is [] (empty list)
 // So one insert: proofs = [[]] (one empty proof)
-export function encodeModifyRedeemer(proofs: unknown[][]): string {
+export function encodeModifyRedeemer(proofs: Data[][]): string {
   return Data.to(new Constr(2, [proofs]));
 }
 
@@ -71,10 +71,18 @@ export function encodeRequestDatum(
   key: string,
   value: string,
   fee: bigint = 0n,
+  submittedAt: bigint = 0n,
 ): string {
   const tokenId = new Constr(0, [assetName]);
   const operation = new Constr(0, [value]); // Insert
-  const request = new Constr(0, [tokenId, ownerHash, key, operation, fee]);
+  const request = new Constr(0, [
+    tokenId,
+    ownerHash,
+    key,
+    operation,
+    fee,
+    submittedAt,
+  ]);
   return Data.to(new Constr(0, [request]));
 }
 
@@ -85,9 +93,22 @@ export function encodeDeleteRequestDatum(
   key: string,
   value: string,
   fee: bigint = 0n,
+  submittedAt: bigint = 0n,
 ): string {
   const tokenId = new Constr(0, [assetName]);
   const operation = new Constr(1, [value]); // Delete
-  const request = new Constr(0, [tokenId, ownerHash, key, operation, fee]);
+  const request = new Constr(0, [
+    tokenId,
+    ownerHash,
+    key,
+    operation,
+    fee,
+    submittedAt,
+  ]);
   return Data.to(new Constr(0, [request]));
+}
+
+// Reject is index 4 (no fields)
+export function encodeRejectRedeemer(): string {
+  return Data.to(new Constr(4, []));
 }

--- a/e2e/src/migration.test.ts
+++ b/e2e/src/migration.test.ts
@@ -28,8 +28,8 @@ describe("MPF Cage Migration E2E", () => {
     ownerKeyHash = details.paymentCredential!.hash;
   });
 
-  const PROCESS_TIME = 60_000n;
-  const RETRACT_TIME = 60_000n;
+  const PROCESS_TIME = 600_000n; // 10 minutes
+  const RETRACT_TIME = 600_000n;
 
   it("mint and end on single version", async () => {
     await cage(

--- a/spec/CageDatum.lean
+++ b/spec/CageDatum.lean
@@ -1,0 +1,423 @@
+/-
+  Formal specification of the MPF Cage validators.
+
+  This file extracts the essential safety properties of the on-chain
+  validators as Lean 4 propositions. It is a *specification* — it
+  defines the abstract model and states what must hold, without
+  providing machine-checked proofs (those would require a Plutus
+  semantics formalisation).
+
+  The properties map 1-to-1 to the 16 categories in
+  `docs/architecture/properties.md` and the 67 Aiken inline tests.
+-/
+
+-- ============================================================================
+-- Abstract types
+-- ============================================================================
+
+/-- 28-byte Ed25519 public-key hash. -/
+opaque def VKH := ByteArray
+
+/-- 32-byte hash (SHA2-256 or Blake2b-256). -/
+opaque def Hash := ByteArray
+
+/-- Arbitrary-length byte string used as MPF keys and values. -/
+abbrev Bytes := ByteArray
+
+/-- A POSIX timestamp in milliseconds. -/
+abbrev POSIXTime := Int
+
+/-- A time interval `[lo, hi]` representing `tx.validity_range`. -/
+structure Interval where
+  lo : POSIXTime
+  hi : POSIXTime
+
+/-- An unspent transaction output reference. -/
+structure OutputReference where
+  txId : Hash
+  index : Nat
+
+/-- Asset name (derived from SHA2-256 of an OutputReference). -/
+abbrev AssetName := Hash
+
+/-- Policy ID (= script hash for a combined minting+spending validator). -/
+abbrev PolicyId := Hash
+
+/-- Token identity — asset name only; policy ID is always the script's own. -/
+structure TokenId where
+  assetName : AssetName
+
+-- ============================================================================
+-- On-chain data structures
+-- ============================================================================
+
+/-- MPF modification operations. -/
+inductive Operation where
+  | Insert  (value : Bytes)
+  | Delete  (value : Bytes)
+  | Update  (oldValue newValue : Bytes)
+
+/-- State datum — attached to the UTxO holding the MPF token. -/
+structure State where
+  owner  : VKH
+  root   : Hash       -- current MPF root (Blake2b-256)
+  maxFee : Nat        -- max lovelace fee per request
+
+/-- Request datum — attached to pending modification request UTxOs. -/
+structure Request where
+  requestToken : TokenId
+  requestOwner : VKH
+  requestKey   : Bytes
+  requestValue : Operation
+  fee          : Nat
+  submittedAt  : POSIXTime
+
+/-- Datum discriminator for UTxOs at the script address. -/
+inductive CageDatum where
+  | RequestDatum (r : Request)
+  | StateDatum   (s : State)
+
+-- ============================================================================
+-- Redeemers
+-- ============================================================================
+
+inductive MintRedeemer where
+  | Minting    (asset : OutputReference)
+  | Migrating  (oldPolicy : PolicyId) (tokenId : TokenId)
+  | Burning
+
+/-- Abstract Merkle proof (opaque — verified by the MPF library). -/
+opaque def Proof := Unit
+
+inductive SpendRedeemer where
+  | End
+  | Contribute (stateRef : OutputReference)
+  | Modify     (proofs : List Proof)
+  | Retract
+  | Reject
+
+-- ============================================================================
+-- Transaction model (abstract)
+-- ============================================================================
+
+structure TxInput where
+  ref     : OutputReference
+  value   : Nat             -- lovelace
+  datum   : Option CageDatum
+  address : PolicyId        -- payment credential (script hash)
+  token   : Option TokenId  -- single non-ADA token, if any
+
+structure TxOutput where
+  value   : Nat
+  datum   : Option CageDatum
+  address : PolicyId
+  token   : Option TokenId
+
+structure Transaction where
+  inputs          : List TxInput
+  outputs         : List TxOutput
+  mint            : PolicyId → TokenId → Int   -- (policy, token) → quantity
+  extraSignatories : List VKH
+  validityRange   : Interval
+
+-- ============================================================================
+-- Validator parameters (immutable per deployment)
+-- ============================================================================
+
+structure ValidatorParams where
+  version     : Nat
+  processTime : Nat        -- Phase 1 duration (ms)
+  retractTime : Nat        -- Phase 2 duration (ms)
+
+-- ============================================================================
+-- Phase predicates
+-- ============================================================================
+
+/-- The entire validity range falls before the deadline. -/
+def Interval.isEntirelyBefore (vr : Interval) (deadline : POSIXTime) : Prop :=
+  vr.hi < deadline
+
+/-- The entire validity range falls at or after the threshold. -/
+def Interval.isEntirelyAfter (vr : Interval) (threshold : POSIXTime) : Prop :=
+  vr.lo > threshold
+
+/-- Phase 1: oracle-exclusive processing window.
+    `[submittedAt, submittedAt + processTime)` -/
+def inPhase1 (vr : Interval) (submittedAt : POSIXTime) (p : ValidatorParams) : Prop :=
+  vr.isEntirelyBefore (submittedAt + p.processTime)
+
+/-- Phase 2: requester-exclusive retract window.
+    `[submittedAt + processTime, submittedAt + processTime + retractTime)` -/
+def inPhase2 (vr : Interval) (submittedAt : POSIXTime) (p : ValidatorParams) : Prop :=
+  vr.isEntirelyAfter (submittedAt + p.processTime - 1) ∧
+  vr.isEntirelyBefore (submittedAt + p.processTime + p.retractTime)
+
+/-- A request is rejectable when it is in Phase 3 or has a dishonest
+    (future) `submittedAt`. -/
+def isRejectable (vr : Interval) (submittedAt : POSIXTime) (p : ValidatorParams) : Prop :=
+  vr.isEntirelyAfter (submittedAt + p.processTime + p.retractTime - 1) ∨
+  vr.isEntirelyBefore submittedAt
+
+-- ============================================================================
+-- Abstract MPF operations
+-- ============================================================================
+
+/-- Apply an operation to an MPF root using a proof. Returns the new root.
+    We treat this as an axiom — correctness is guaranteed by the
+    `aiken-lang/merkle-patricia-forestry` library. -/
+axiom mpfApply (root : Hash) (key : Bytes) (op : Operation) (proof : Proof) : Hash
+
+/-- The well-known root hash of the empty trie. -/
+axiom emptyRoot : Hash
+
+-- ============================================================================
+-- Derived predicates
+-- ============================================================================
+
+def isSigner (tx : Transaction) (vkh : VKH) : Prop :=
+  vkh ∈ tx.extraSignatories
+
+def assetName (ref : OutputReference) : AssetName :=
+  sorry  -- SHA2-256(ref.txId ++ bigEndian16(ref.index))
+
+-- ============================================================================
+-- 1. Token uniqueness
+-- ============================================================================
+
+/-- Determinism: same OutputReference always yields the same AssetName. -/
+theorem assetName_deterministic (ref : OutputReference) :
+    assetName ref = assetName ref := rfl
+
+/-- Collision resistance: distinct OutputReferences yield distinct
+    AssetNames (by SHA2-256 collision resistance). -/
+axiom assetName_injective :
+    ∀ r₁ r₂ : OutputReference, assetName r₁ = assetName r₂ → r₁ = r₂
+
+-- ============================================================================
+-- 2. Minting integrity
+-- ============================================================================
+
+/-- A Minting transaction is valid iff all four conditions hold. -/
+structure ValidMint (policyId : PolicyId) (tx : Transaction)
+    (asset : OutputReference) : Prop where
+  /-- The referenced UTxO is consumed. -/
+  consumed  : ∃ i ∈ tx.inputs, i.ref = asset
+  /-- Exactly one token is minted. -/
+  quantity  : tx.mint policyId ⟨assetName asset⟩ = 1
+  /-- First output goes to this script. -/
+  toScript  : ∃ o ∈ tx.outputs, tx.outputs.head? = some o ∧ o.address = policyId
+  /-- Output datum is StateDatum with empty root. -/
+  emptyInit : ∃ o ∈ tx.outputs, tx.outputs.head? = some o ∧
+              o.datum = some (CageDatum.StateDatum ⟨·, emptyRoot, ·⟩)
+
+-- ============================================================================
+-- 3. Ownership & authorization
+-- ============================================================================
+
+/-- Oracle operations require the state owner's signature. -/
+def oracleAuthorized (state : State) (tx : Transaction) : Prop :=
+  isSigner tx state.owner
+
+/-- Retract requires the request owner's signature. -/
+def retractAuthorized (request : Request) (tx : Transaction) : Prop :=
+  isSigner tx request.requestOwner
+
+-- ============================================================================
+-- 4. Token confinement
+-- ============================================================================
+
+/-- After Modify or Reject the token stays at the same script address. -/
+def tokenConfined (input : TxInput) (output : TxOutput) : Prop :=
+  output.address = input.address
+
+-- ============================================================================
+-- 5. Ownership transfer
+-- ============================================================================
+
+/-- The owner field in the output datum is unchecked during Modify —
+    the current owner can transfer to a new key. -/
+def ownerTransferAllowed (inputState outputState : State) : Prop :=
+  True  -- no constraint on outputState.owner
+
+-- ============================================================================
+-- 6. State integrity (MPF root)
+-- ============================================================================
+
+/-- The output root equals the result of folding all matching request
+    operations over the input root. -/
+def rootIntegrity
+    (inputRoot : Hash)
+    (requests : List (Request × Proof))
+    (outputRoot : Hash) : Prop :=
+  outputRoot = requests.foldl
+    (fun root (req, proof) => mpfApply root req.requestKey req.requestValue proof)
+    inputRoot
+
+-- ============================================================================
+-- 7. Proof consumption
+-- ============================================================================
+
+/-- Exactly one proof is consumed per matching request.
+    Too few proofs → failure. Extra proofs are silently ignored. -/
+def proofConsumption
+    (matchingRequests : List Request)
+    (proofs : List Proof) : Prop :=
+  matchingRequests.length ≤ proofs.length
+
+-- ============================================================================
+-- 8. Request binding
+-- ============================================================================
+
+/-- A Contribute validates that the request's target token matches the
+    actual token at the referenced state UTxO. -/
+def requestBound (request : Request) (stateToken : TokenId) : Prop :=
+  request.requestToken = stateToken
+
+-- ============================================================================
+-- 9. Datum-redeemer type safety
+-- ============================================================================
+
+/-- Each redeemer expects a specific datum constructor. -/
+def datumRedeemerCompat : SpendRedeemer → CageDatum → Prop
+  | .Retract,       .RequestDatum _ => True
+  | .Contribute _,  .RequestDatum _ => True
+  | .Modify _,      .StateDatum _   => True
+  | .End,           .StateDatum _   => True
+  | .Reject,        .StateDatum _   => True
+  | _,              _               => False
+
+-- ============================================================================
+-- 10. Datum presence
+-- ============================================================================
+
+/-- Every cage UTxO must carry a datum. UTxOs with `None` are unspendable. -/
+def datumPresent (datum : Option CageDatum) : Prop :=
+  datum.isSome
+
+-- ============================================================================
+-- 11. End / burn integrity
+-- ============================================================================
+
+/-- End requires the mint field to contain exactly -1 of the caged token. -/
+def burnIntegrity (policyId : PolicyId) (tokenId : TokenId) (tx : Transaction) : Prop :=
+  tx.mint policyId tokenId = -1
+
+-- ============================================================================
+-- 12. Token extraction
+-- ============================================================================
+
+/-- `tokenFromValue` returns `Some` iff the value contains exactly one
+    non-ADA policy with exactly one asset name. -/
+-- (Modelled abstractly via the TxInput.token field.)
+
+-- ============================================================================
+-- 13. Time-gated phases (exclusivity)
+-- ============================================================================
+
+/-- Phases are mutually exclusive: no validity range can satisfy two phases. -/
+theorem phase_exclusivity (vr : Interval) (sa : POSIXTime) (p : ValidatorParams)
+    (hpt : 0 < p.processTime) (hrt : 0 < p.retractTime) :
+    ¬(inPhase1 vr sa p ∧ inPhase2 vr sa p) := by
+  intro ⟨h1, h2lo, _⟩
+  -- inPhase1 says vr.hi < sa + pt, inPhase2 says vr.lo > sa + pt - 1
+  -- Since vr.lo ≤ vr.hi, we get sa + pt - 1 < vr.lo ≤ vr.hi < sa + pt
+  -- i.e. sa + pt - 1 < sa + pt which is trivially true, but we also need
+  -- vr.lo ≤ vr.hi which gives the contradiction.
+  sorry  -- requires Interval well-formedness axiom (lo ≤ hi)
+
+/-- Phase 2 and rejectability (Phase 3 branch) are mutually exclusive. -/
+theorem phase2_reject_exclusive (vr : Interval) (sa : POSIXTime) (p : ValidatorParams) :
+    ¬(inPhase2 vr sa p ∧
+      vr.isEntirelyAfter (sa + p.processTime + p.retractTime - 1)) := by
+  intro ⟨⟨_, h2hi⟩, h3lo⟩
+  -- h2hi: vr.hi < sa + pt + rt
+  -- h3lo: vr.lo > sa + pt + rt - 1, i.e. vr.lo ≥ sa + pt + rt
+  -- Since lo ≤ hi: sa + pt + rt ≤ vr.lo ≤ vr.hi < sa + pt + rt → contradiction
+  sorry
+
+-- ============================================================================
+-- 14. Reject (DDoS protection)
+-- ============================================================================
+
+/-- A Reject transaction is valid iff all of the following hold. -/
+structure ValidReject (p : ValidatorParams) (state : State)
+    (stateInput : TxInput) (tx : Transaction)
+    (requests : List (TxInput × Request)) : Prop where
+  /-- Owner signed. -/
+  auth      : oracleAuthorized state tx
+  /-- Root unchanged. -/
+  rootSame  : ∀ o ∈ tx.outputs, tx.outputs.head? = some o →
+              ∃ s, o.datum = some (CageDatum.StateDatum s) ∧ s.root = state.root
+  /-- Token confined. -/
+  confined  : ∀ o ∈ tx.outputs, tx.outputs.head? = some o →
+              o.address = stateInput.address
+  /-- Each request is rejectable. -/
+  rejectable : ∀ (pair : TxInput × Request), pair ∈ requests →
+               isRejectable tx.validityRange pair.2.submittedAt p
+  /-- Each request fee matches state max_fee. -/
+  feeMatch  : ∀ (pair : TxInput × Request), pair ∈ requests →
+              pair.2.fee = state.maxFee
+  /-- Refunds: each requester receives inputLovelace - fee. -/
+  refunds   : ∀ (pair : TxInput × Request), pair ∈ requests →
+              ∃ o ∈ tx.outputs,
+                o.address = sorry ∧  -- requestOwner's address
+                o.value ≥ pair.1.value - pair.2.fee
+
+-- ============================================================================
+-- 15. Fee enforcement
+-- ============================================================================
+
+/-- During Modify, each request's fee must equal the state's max_fee,
+    and the requester is refunded inputLovelace - fee. -/
+structure FeeEnforced (state : State) (reqInput : TxInput)
+    (request : Request) (tx : Transaction) : Prop where
+  feeMatch : request.fee = state.maxFee
+  refund   : ∃ o ∈ tx.outputs,
+             o.value ≥ reqInput.value - request.fee
+
+-- ============================================================================
+-- 16. Migration
+-- ============================================================================
+
+/-- A Migration transaction is valid iff the old token is burned and a new
+    token is minted, output goes to the new script, and carries a StateDatum. -/
+structure ValidMigration (oldPolicy newPolicy : PolicyId)
+    (tokenId : TokenId) (tx : Transaction) : Prop where
+  oldBurned : tx.mint oldPolicy tokenId = -1
+  newMinted : tx.mint newPolicy tokenId = 1
+  toScript  : ∃ o ∈ tx.outputs, tx.outputs.head? = some o ∧ o.address = newPolicy
+  hasDatum  : ∃ o ∈ tx.outputs, tx.outputs.head? = some o ∧
+              ∃ s, o.datum = some (CageDatum.StateDatum s)
+
+-- ============================================================================
+-- Composite validator property
+-- ============================================================================
+
+/-- Top-level spend acceptance — the conjunction of all applicable properties
+    depending on the redeemer. -/
+def validSpend (p : ValidatorParams) (policyId : PolicyId)
+    (datum : CageDatum) (redeemer : SpendRedeemer)
+    (self : TxInput) (tx : Transaction) : Prop :=
+  datumPresent (some datum) ∧
+  datumRedeemerCompat redeemer datum ∧
+  match redeemer, datum with
+  | .Retract, .RequestDatum req =>
+      retractAuthorized req tx ∧
+      inPhase2 tx.validityRange req.submittedAt p
+  | .Contribute stateRef, .RequestDatum req =>
+      (∃ si ∈ tx.inputs, si.ref = stateRef ∧
+       ∃ tid, si.token = some tid ∧ requestBound req tid) ∧
+      (inPhase1 tx.validityRange req.submittedAt p ∨
+       isRejectable tx.validityRange req.submittedAt p)
+  | .Modify proofs, .StateDatum state =>
+      oracleAuthorized state tx ∧
+      (∃ o, tx.outputs.head? = some o ∧ tokenConfined self o) ∧
+      True  -- + rootIntegrity + feeEnforced + proofConsumption (elided)
+  | .Reject, .StateDatum state =>
+      oracleAuthorized state tx ∧
+      (∃ o, tx.outputs.head? = some o ∧ tokenConfined self o ∧
+       ∃ s, o.datum = some (CageDatum.StateDatum s) ∧ s.root = state.root)
+  | .End, .StateDatum state =>
+      oracleAuthorized state tx ∧
+      burnIntegrity policyId (sorry : TokenId) tx  -- token extracted from self
+  | _, _ => False

--- a/validators/cage.ak
+++ b/validators/cage.ak
@@ -100,6 +100,7 @@
 use aiken/collection/list
 use aiken/collection/list.{find, foldl, has, head}
 use aiken/crypto.{VerificationKeyHash}
+use aiken/interval
 use aiken/merkle_patricia_forestry.{MerklePatriciaForestry, Proof, empty, root}
 use aiken/merkle_patricia_forestry as mpf
 use aiken/option.{is_some}
@@ -114,8 +115,8 @@ use cardano/transaction.{
 use lib.{TokenId, assetName, quantity, tokenFromValue, valueFromToken}
 use types.{
   Burning, CageDatum, Contribute, Delete, End, Insert, Migrating, Migration, Mint,
-  MintRedeemer, Minting, Modify, Request, RequestDatum, Retract, State, StateDatum,
-  Update, UpdateRedeemer,
+  MintRedeemer, Minting, Modify, Reject, Request, RequestDatum, Retract, State,
+  StateDatum, Update, UpdateRedeemer,
 }
 
 /// The main validator for caged MPF tokens.
@@ -131,7 +132,7 @@ use types.{
 /// spending validator (`spend`) runs because the UTxO is at this script's
 /// address. The `else(_)` handler rejects any other purpose (e.g.,
 /// withdrawal, certify).
-validator mpfCage(_version: Int) {
+validator mpfCage(_version: Int, process_time: Int, retract_time: Int) {
   /// Minting policy: validates creation and destruction of caged tokens.
   ///
   /// - `Minting`: Creates a new caged token with an empty MPF root.
@@ -214,38 +215,21 @@ validator mpfCage(_version: Int) {
     when redeemer is {
       Retract -> {
         // --- RETRACT PATH ---
-        // Only valid for Request UTxOs. Allows the request creator to
-        // reclaim their UTxO (and its ADA) if the cage owner hasn't
-        // processed the request yet.
-        //
-        // Fail if datum is not a RequestDatum (e.g., if someone tries
-        // to Retract a State UTxO, this expect will fail)
+        // Only valid for Request UTxOs during Phase 2 (retract window).
         expect RequestDatum(request) = datum
-        // Extract the request owner's verification key hash
-        let Request { requestOwner, .. } = request
-        let Transaction { extra_signatories, .. } = tx
-        // Fail if the request owner hasn't signed the transaction.
-        // This ensures only the original request creator can retract.
-        // Note: no other checks are needed -- the request UTxO is simply
-        // consumed, and its ADA goes wherever the transaction specifies.
+        let Request { requestOwner, submitted_at, .. } = request
+        let Transaction { extra_signatories, validity_range, .. } = tx
         expect has(extra_signatories, requestOwner)
+        // Phase 2: retract window is open
+        expect
+          in_phase2(validity_range, submitted_at, process_time, retract_time)
         True
       }
       Contribute(tokenRef) -> {
         // --- CONTRIBUTE PATH ---
-        // Valid for Request UTxOs. This is a permissionless operation
-        // that validates a request targets the correct caged token.
-        //
-        // The `tokenRef` is the OutputReference of the State UTxO that
-        // holds the caged NFT. The validator looks up this input and
-        // extracts the token to compare against the request's target.
-        //
-        // Fail if datum is not a RequestDatum
+        // Valid for Request UTxOs in Phase 1 or when rejectable.
         expect RequestDatum(request) = datum
-        // Validate that the request's target token matches the actual
-        // token at tokenRef. This prevents requests from being applied
-        // to the wrong cage.
-        validRequest(request, tokenRef, tx)
+        validRequest(request, tokenRef, tx, process_time, retract_time)
       }
       _ -> {
         // --- MODIFY / END PATH ---
@@ -263,7 +247,24 @@ validator mpfCage(_version: Int) {
         // TokenId (for identifying which token is being operated on).
         let (input, tokenId) = extractToken(self, tx)
         when redeemer is {
-          Modify(proofs) -> validRootUpdate(state, input, tokenId, tx, proofs)
+          Modify(proofs) ->
+            validRootUpdate(
+              state,
+              input,
+              tokenId,
+              tx,
+              proofs,
+              process_time,
+            )
+          Reject ->
+            validReject(
+              state,
+              input,
+              tokenId,
+              tx,
+              process_time,
+              retract_time,
+            )
           End -> {
             expect address.Script(policyId) =
               input.output.address.payment_credential
@@ -398,10 +399,26 @@ fn validateOwnership(state: State, tx: Transaction) {
 /// - requestToken matches token at tokenRef -> True
 /// - requestToken differs from token at tokenRef -> fail
 /// - tokenRef not in inputs -> fail (extractToken fails)
-fn validRequest(request: Request, tokenRef: OutputReference, tx: Transaction) {
-  let Request { requestToken, .. } = request
+fn validRequest(
+  request: Request,
+  tokenRef: OutputReference,
+  tx: Transaction,
+  process_time: Int,
+  retract_time: Int,
+) {
+  let Request { requestToken, submitted_at, .. } = request
   let (_input, tokenId) = extractToken(tokenRef, tx)
   expect requestToken == tokenId
+  let Transaction { validity_range, .. } = tx
+  // Phase 1 or rejectable (NOT Phase 2 — requester-exclusive)
+  expect
+    in_phase1(validity_range, submitted_at, process_time)
+      || is_rejectable(
+          validity_range,
+          submitted_at,
+          process_time,
+          retract_time,
+        )
   True
 }
 
@@ -430,6 +447,48 @@ fn uncons(list: List<a>, cont: fn(a, List<a>) -> b) -> b {
     [] -> fail
     [x, ..xs] -> cont(x, xs)
   }
+}
+
+/// Check if the validity range is entirely within Phase 1 (oracle processing).
+/// Phase 1: from submitted_at to submitted_at + process_time (exclusive).
+fn in_phase1(validity_range, submitted_at, process_time) -> Bool {
+  interval.is_entirely_before(validity_range, submitted_at + process_time)
+}
+
+/// Check if the validity range is entirely within Phase 2 (requester retract).
+/// Phase 2: from submitted_at + process_time to
+///          submitted_at + process_time + retract_time (exclusive).
+fn in_phase2(
+  validity_range,
+  submitted_at,
+  process_time,
+  retract_time,
+) -> Bool {
+  interval.is_entirely_after(
+    validity_range,
+    submitted_at + process_time - 1,
+  )
+    && interval.is_entirely_before(
+        validity_range,
+        submitted_at + process_time + retract_time,
+      )
+}
+
+/// Check if a request is rejectable: Phase 3 (retract expired) or
+/// dishonest (submitted_at is in the future).
+fn is_rejectable(
+  validity_range,
+  submitted_at,
+  process_time,
+  retract_time,
+) -> Bool {
+  // Phase 3: retract window expired
+  interval.is_entirely_after(
+    validity_range,
+    submitted_at + process_time + retract_time - 1,
+  )
+    // OR dishonest: submitted_at is in the future
+    || interval.is_entirely_before(validity_range, submitted_at)
 }
 
 /// Create an update function for folding requests into the MPF.
@@ -502,7 +561,7 @@ fn uncons(list: List<a>, cont: fn(a, List<a>) -> b) -> b {
 /// - Request with Insert on existing key -> mpf.insert fails
 /// - Request with Delete on non-existent key -> mpf.delete fails
 /// - Request with Update with wrong old value -> mpf.update fails
-fn mkUpdate(tokenId, max_fee) {
+fn mkUpdate(tokenId, max_fee, process_time, validity_range) {
   fn(
     input: Input,
     acc: (
@@ -524,10 +583,13 @@ fn mkUpdate(tokenId, max_fee) {
             requestValue,
             requestOwner,
             fee,
+            submitted_at,
           } = request
           if requestToken == tokenId {
             // Fee must match the state's max_fee
             expect fee == max_fee
+            // Request must be in Phase 1
+            expect in_phase1(validity_range, submitted_at, process_time)
             let (root, proofs, refunds) = acc
             let proof, proofsTail <- uncons(proofs)
             let newRoot =
@@ -647,8 +709,9 @@ fn validRootUpdate(
   tokenId: TokenId,
   tx: Transaction,
   proofs: List<Proof>,
+  process_time: Int,
 ) {
-  let Transaction { outputs, inputs, .. } = tx
+  let Transaction { outputs, inputs, validity_range, .. } = tx
   let State { root, max_fee, .. } = state
   expect Some(output) = head(outputs)
   expect InlineDatum(state) = output.datum
@@ -656,12 +719,102 @@ fn validRootUpdate(
 
   let (expectedNewRoot, _, refunds) =
     inputs
-      |> foldl((mpf.from_root(root), proofs, []), mkUpdate(tokenId, max_fee))
+      |> foldl(
+          (mpf.from_root(root), proofs, []),
+          mkUpdate(tokenId, max_fee, process_time, validity_range),
+        )
   expect (mpf.root(expectedNewRoot) == newRoot)?
   expect
     output.address.payment_credential == input.output.address.payment_credential
 
   // Verify refund outputs (starting after the State UTxO at index 0)
+  expect [_, ..refundOutputs] = outputs
+  let orderedRefunds = list.reverse(refunds)
+  expect verifyRefunds(refundOutputs, orderedRefunds)
+  True
+}
+
+/// Create a reject function for folding over inputs to collect refunds.
+/// Like mkUpdate but: no proofs, no MPF operations, is_rejectable check.
+fn mkReject(
+  tokenId,
+  max_fee,
+  process_time,
+  retract_time,
+  validity_range,
+) {
+  fn(input: Input, refunds: List<Pair<VerificationKeyHash, Int>>) {
+    when input.output.datum is {
+      InlineDatum(datum) ->
+        if datum is RequestDatum(request): CageDatum {
+          let Request {
+            requestToken,
+            requestOwner,
+            fee,
+            submitted_at,
+            ..
+          } = request
+          if requestToken == tokenId {
+            expect fee == max_fee
+            expect
+              is_rejectable(
+                validity_range,
+                submitted_at,
+                process_time,
+                retract_time,
+              )
+            let inputLovelace = assets.lovelace_of(input.output.value)
+            let refundAmount = inputLovelace - fee
+            if refundAmount > 0 {
+              [Pair(requestOwner, refundAmount), ..refunds]
+            } else {
+              refunds
+            }
+          } else {
+            refunds
+          }
+        } else {
+          refunds
+        }
+      _ -> refunds
+    }
+  }
+}
+
+/// Validate a Reject operation: discard expired/dishonest requests.
+/// Root MUST NOT change. Refunds enforced for each rejected request.
+fn validReject(
+  state: State,
+  input: Input,
+  tokenId: TokenId,
+  tx: Transaction,
+  process_time: Int,
+  retract_time: Int,
+) {
+  let Transaction { outputs, inputs, validity_range, .. } = tx
+  let State { root, max_fee, .. } = state
+
+  expect Some(output) = head(outputs)
+  expect InlineDatum(outState) = output.datum
+  expect StateDatum(State { root: newRoot, .. }) = outState
+  expect newRoot == root
+
+  expect
+    output.address.payment_credential == input.output.address.payment_credential
+
+  let refunds =
+    inputs
+      |> foldl(
+          [],
+          mkReject(
+            tokenId,
+            max_fee,
+            process_time,
+            retract_time,
+            validity_range,
+          ),
+        )
+
   expect [_, ..refundOutputs] = outputs
   let orderedRefunds = list.reverse(refunds)
   expect verifyRefunds(refundOutputs, orderedRefunds)
@@ -803,6 +956,20 @@ pub fn validateMigration(
 // Tests
 // ============================================================================
 
+// Test time params: 10s process window, 10s retract window
+const testProcessTime = 10_000
+
+const testRetractTime = 10_000
+
+// Phase 1 validity range: [0, 5_000] — entirely before submitted_at(0) + process_time(10_000)
+const phase1Range = interval.between(0, 5_000)
+
+// Phase 2 validity range: [10_000, 15_000] — after process_time, before process_time + retract_time
+const phase2Range = interval.between(10_000, 15_000)
+
+// Phase 3 validity range: [20_000, 25_000] — after process_time + retract_time
+const phase3Range = interval.between(20_000, 25_000)
+
 // Test constants: a script address used for all test UTxOs
 const testScriptAddress = from_script("policy_id")
 
@@ -832,6 +999,7 @@ const aRequest =
       requestValue: Insert("42"),
       requestOwner: "owner",
       fee: 0,
+      submitted_at: 0,
     },
   )
 
@@ -891,21 +1059,30 @@ const output =
 test canCage() {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     Modify([[]]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [output],
       extra_signatories: ["owner"],
       inputs: [update, request],
     },
   ) && mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     Some(aRequest),
     Contribute(testStateRef),
     testRequestRef,
-    Transaction { ..transaction.placeholder, inputs: [update, request] },
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase1Range,
+      inputs: [update, request],
+    },
   )
 }
 
@@ -960,6 +1137,8 @@ const consumed_utxo =
 test canMint() {
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Minting(minting),
     "policy_id",
     Transaction {
@@ -988,6 +1167,8 @@ fn mint_tx() -> Transaction {
 test mint_missing_input() fail {
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Minting(minting),
     "policy_id",
     Transaction { ..mint_tx(), inputs: [] },
@@ -997,6 +1178,8 @@ test mint_missing_input() fail {
 test mint_quantity_two() fail {
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Minting(minting),
     "policy_id",
     Transaction {
@@ -1011,6 +1194,8 @@ test mint_to_wallet() fail {
     Output { ..minted, address: address.from_verification_key("someone") }
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Minting(minting),
     "policy_id",
     Transaction { ..mint_tx(), outputs: [wallet_output] },
@@ -1022,6 +1207,8 @@ test mint_to_wrong_script() fail {
     Output { ..minted, address: address.from_script("other_script") }
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Minting(minting),
     "policy_id",
     Transaction { ..mint_tx(), outputs: [wrong_output] },
@@ -1038,6 +1225,8 @@ test mint_nonempty_root() fail {
     }
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Minting(minting),
     "policy_id",
     Transaction { ..mint_tx(), outputs: [bad_output] },
@@ -1056,12 +1245,15 @@ test mint_request_datum() fail {
             requestValue: Insert("v"),
             requestOwner: "owner",
             fee: 0,
+            submitted_at: 0,
           },
         ),
       ),
     }
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Minting(minting),
     "policy_id",
     Transaction { ..mint_tx(), outputs: [bad_output] },
@@ -1072,6 +1264,8 @@ test mint_no_datum() fail {
   let bad_output = Output { ..minted, datum: NoDatum }
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Minting(minting),
     "policy_id",
     Transaction { ..mint_tx(), outputs: [bad_output] },
@@ -1085,11 +1279,14 @@ test mint_no_datum() fail {
 test retract_happy() {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     Some(aRequest),
     Retract,
     testRequestRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase2Range,
       extra_signatories: ["owner"],
     },
   )
@@ -1098,12 +1295,47 @@ test retract_happy() {
 test retract_wrong_signer() fail {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     Some(aRequest),
     Retract,
     testRequestRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase2Range,
       extra_signatories: ["someone_else"],
+    },
+  )
+}
+
+test retract_in_phase1() fail {
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    Some(aRequest),
+    Retract,
+    testRequestRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase1Range,
+      extra_signatories: ["owner"],
+    },
+  )
+}
+
+test retract_in_phase3() fail {
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    Some(aRequest),
+    Retract,
+    testRequestRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase3Range,
+      extra_signatories: ["owner"],
     },
   )
 }
@@ -1121,14 +1353,21 @@ test contribute_wrong_token() fail {
         requestValue: Insert("42"),
         requestOwner: "owner",
         fee: 0,
+        submitted_at: 0,
       },
     )
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     Some(wrong_request),
     Contribute(testStateRef),
     testRequestRef,
-    Transaction { ..transaction.placeholder, inputs: [update, request] },
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase1Range,
+      inputs: [update, request],
+    },
   )
 }
 
@@ -1137,10 +1376,49 @@ test contribute_missing_ref() fail {
     OutputReference { transaction_id: "nonexistent", output_index: 0 }
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     Some(aRequest),
     Contribute(missing_ref),
     testRequestRef,
-    Transaction { ..transaction.placeholder, inputs: [update, request] },
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase1Range,
+      inputs: [update, request],
+    },
+  )
+}
+
+test contribute_in_phase2() fail {
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    Some(aRequest),
+    Contribute(testStateRef),
+    testRequestRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase2Range,
+      inputs: [update, request],
+    },
+  )
+}
+
+test contribute_in_phase3() {
+  // Phase 3 is rejectable — Contribute is allowed for Reject tx
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    Some(aRequest),
+    Contribute(testStateRef),
+    testRequestRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase3Range,
+      inputs: [update, request],
+    },
   )
 }
 
@@ -1151,11 +1429,14 @@ test contribute_missing_ref() fail {
 test modify_missing_signature() fail {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     Modify([[]]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [output],
       extra_signatories: [],
       inputs: [update, request],
@@ -1171,11 +1452,14 @@ test modify_wrong_address() fail {
     }
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     Modify([[]]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [bad_output],
       extra_signatories: ["owner"],
       inputs: [update, request],
@@ -1187,11 +1471,14 @@ test modify_owner_transfer() {
   // output already has owner: "new-owner", this should succeed
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     Modify([[]]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [output],
       extra_signatories: ["owner"],
       inputs: [update, request],
@@ -1212,11 +1499,14 @@ test modify_no_requests() {
     }
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     Modify([]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [unchanged_output],
       extra_signatories: ["owner"],
       inputs: [update],
@@ -1234,6 +1524,7 @@ test modify_skip_other_token() {
         requestValue: Insert("42"),
         requestOwner: "someone",
         fee: 0,
+        submitted_at: 0,
       },
     )
   let other_request =
@@ -1260,11 +1551,14 @@ test modify_skip_other_token() {
     }
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     Modify([]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [unchanged_output],
       extra_signatories: ["owner"],
       inputs: [update, other_request],
@@ -1276,11 +1570,14 @@ test modify_too_few_proofs() fail {
   // One matching request but zero proofs
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     Modify([]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [output],
       extra_signatories: ["owner"],
       inputs: [update, request],
@@ -1292,11 +1589,14 @@ test modify_extra_proofs() {
   // One matching request, two proofs — extra proof is ignored
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     Modify([[], []]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [output],
       extra_signatories: ["owner"],
       inputs: [update, request],
@@ -1318,12 +1618,34 @@ test modify_wrong_root() fail {
     }
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     Modify([[]]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [bad_root_output],
+      extra_signatories: ["owner"],
+      inputs: [update, request],
+    },
+  )
+}
+
+test modify_in_phase2() fail {
+  // Modify should fail when validity range is in Phase 2
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    stateDatum,
+    Modify([[]]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase2Range,
+      outputs: [output],
       extra_signatories: ["owner"],
       inputs: [update, request],
     },
@@ -1340,6 +1662,8 @@ const burn_value = from_asset("policy_id", testToken.assetName, -1)
 test end_happy() {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     End,
     testStateRef,
@@ -1355,6 +1679,8 @@ test end_happy() {
 test end_missing_signature() fail {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     End,
     testStateRef,
@@ -1371,6 +1697,8 @@ test end_wrong_token_in_mint() fail {
   let wrong_burn = valueFromToken("policy_id", TokenId { assetName: "wrong" })
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     End,
     testStateRef,
@@ -1390,11 +1718,14 @@ test end_wrong_token_in_mint() fail {
 test retract_on_state_datum() fail {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     Retract,
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase2Range,
       extra_signatories: ["owner"],
     },
   )
@@ -1403,11 +1734,14 @@ test retract_on_state_datum() fail {
 test contribute_on_state_datum() fail {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     Contribute(testStateRef),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       inputs: [update],
     },
   )
@@ -1416,11 +1750,14 @@ test contribute_on_state_datum() fail {
 test modify_on_request_datum() fail {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     Some(aRequest),
     Modify([]),
     testRequestRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       extra_signatories: ["owner"],
       inputs: [request],
     },
@@ -1430,6 +1767,8 @@ test modify_on_request_datum() fail {
 test end_on_request_datum() fail {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     Some(aRequest),
     End,
     testRequestRef,
@@ -1449,6 +1788,8 @@ test end_on_request_datum() fail {
 test spend_no_datum() fail {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     None,
     Retract,
     testRequestRef,
@@ -1475,15 +1816,19 @@ test prop_retract_requires_owner(
         requestValue: Insert("v"),
         requestOwner: "the_real_owner_key_aaaaaaaaaa",
         fee: 0,
+        submitted_at: 0,
       },
     )
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     Some(req),
     Retract,
     testRequestRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase2Range,
       extra_signatories: [signer],
     },
   )
@@ -1525,11 +1870,14 @@ test prop_modify_requires_owner(
     }
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     Some(StateDatum(s)),
     Modify([]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [unchanged_output],
       extra_signatories: [signer],
       inputs: [state_input],
@@ -1567,6 +1915,8 @@ test prop_mint_roundtrip(
     }
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Minting(mint_redeemer),
     "policy_id",
     Transaction {
@@ -1615,6 +1965,8 @@ const migrate_output =
 test canMigrate() {
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Migrating(migrate_redeemer),
     new_policy,
     Transaction {
@@ -1630,6 +1982,8 @@ test migrate_no_burn() fail {
   let mint_no_burn = from_asset(new_policy, migrate_token.assetName, 1)
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Migrating(migrate_redeemer),
     new_policy,
     Transaction {
@@ -1648,6 +2002,8 @@ test migrate_to_wallet() fail {
     }
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Migrating(migrate_redeemer),
     new_policy,
     Transaction {
@@ -1665,6 +2021,8 @@ test migrate_wrong_old_policy() fail {
       |> assets.merge(from_asset(new_policy, migrate_token.assetName, 1))
   mpfCage.mint(
     0,
+    testProcessTime,
+    testRetractTime,
     Migrating(migrate_redeemer),
     new_policy,
     Transaction {
@@ -1696,6 +2054,7 @@ const feeRequest =
       requestValue: Insert("42"),
       requestOwner: "requester_key_aaaaaaaaaaaaaaa",
       fee: testFee,
+      submitted_at: 0,
     },
   )
 
@@ -1748,11 +2107,14 @@ const refundOutput =
 test modify_with_refund() {
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     feeStateDatum,
     Modify([[]]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [feeStateOutput, refundOutput],
       extra_signatories: ["owner"],
       inputs: [feeStateInput, feeRequestInput],
@@ -1764,11 +2126,14 @@ test modify_missing_refund() fail {
   // Fee > 0 but no refund output after state output
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     feeStateDatum,
     Modify([[]]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [feeStateOutput],
       extra_signatories: ["owner"],
       inputs: [feeStateInput, feeRequestInput],
@@ -1785,11 +2150,14 @@ test modify_insufficient_refund() fail {
     }
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     feeStateDatum,
     Modify([[]]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [feeStateOutput, bad_refund],
       extra_signatories: ["owner"],
       inputs: [feeStateInput, feeRequestInput],
@@ -1806,11 +2174,14 @@ test modify_wrong_refund_address() fail {
     }
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     feeStateDatum,
     Modify([[]]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [feeStateOutput, wrong_addr_refund],
       extra_signatories: ["owner"],
       inputs: [feeStateInput, feeRequestInput],
@@ -1830,6 +2201,7 @@ test modify_zero_fee() {
         requestValue: Insert("42"),
         requestOwner: "requester_key_aaaaaaaaaaaaaaa",
         fee: 0,
+        submitted_at: 0,
       },
     )
   let zf_request_input =
@@ -1876,11 +2248,14 @@ test modify_zero_fee() {
     }
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     Some(StateDatum(zf_state)),
     Modify([[]]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [zf_state_output, zf_refund],
       extra_signatories: ["owner"],
       inputs: [zf_state_input, zf_request_input],
@@ -1898,6 +2273,7 @@ test modify_fee_mismatch() fail {
         requestValue: Insert("42"),
         requestOwner: "requester_key_aaaaaaaaaaaaaaa",
         fee: 100_000,
+        submitted_at: 0,
       },
     )
   let mismatch_input =
@@ -1912,11 +2288,14 @@ test modify_fee_mismatch() fail {
     }
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     feeStateDatum,
     Modify([[]]),
     testStateRef,
     Transaction {
       ..transaction.placeholder,
+      validity_range: phase1Range,
       outputs: [feeStateOutput, refundOutput],
       extra_signatories: ["owner"],
       inputs: [feeStateInput, mismatch_input],
@@ -1931,6 +2310,8 @@ test end_with_extra_mint_policy() {
       |> assets.merge(from_asset("other_policy", "other_asset", 1))
   mpfCage.spend(
     0,
+    testProcessTime,
+    testRetractTime,
     stateDatum,
     End,
     testStateRef,
@@ -1939,6 +2320,197 @@ test end_with_extra_mint_policy() {
       extra_signatories: ["owner"],
       inputs: [update],
       mint: extra_mint,
+    },
+  )
+}
+
+// ============================================================================
+// Reject tests
+// ============================================================================
+
+// State output for reject: root MUST NOT change (stays empty)
+const rejectStateOutput =
+  Output {
+    address: testScriptAddress,
+    value: testValue,
+    datum: InlineDatum(
+      StateDatum(
+        State { owner: "owner", root: root(mpf.empty), max_fee: testFee },
+      ),
+    ),
+    reference_script: None,
+  }
+
+test reject_happy() {
+  // Phase 3: retract window expired, oracle can reject and keep fee
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    feeStateDatum,
+    Reject,
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase3Range,
+      outputs: [rejectStateOutput, refundOutput],
+      extra_signatories: ["owner"],
+      inputs: [feeStateInput, feeRequestInput],
+    },
+  )
+}
+
+test reject_in_phase1() fail {
+  // Cannot reject during Phase 1 (oracle processing window)
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    feeStateDatum,
+    Reject,
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase1Range,
+      outputs: [rejectStateOutput, refundOutput],
+      extra_signatories: ["owner"],
+      inputs: [feeStateInput, feeRequestInput],
+    },
+  )
+}
+
+test reject_in_phase2() fail {
+  // Cannot reject during Phase 2 (requester retract window)
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    feeStateDatum,
+    Reject,
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase2Range,
+      outputs: [rejectStateOutput, refundOutput],
+      extra_signatories: ["owner"],
+      inputs: [feeStateInput, feeRequestInput],
+    },
+  )
+}
+
+test reject_future_submitted_at() {
+  // Dishonest: submitted_at is in the future → immediately rejectable
+  let future_request =
+    RequestDatum(
+      Request {
+        requestToken: testToken,
+        requestKey: "42",
+        requestValue: Insert("42"),
+        requestOwner: "requester_key_aaaaaaaaaaaaaaa",
+        fee: testFee,
+        submitted_at: 100_000,
+      },
+    )
+  let future_request_input =
+    Input {
+      output_reference: testRequestRef,
+      output: Output {
+        address: testScriptAddress,
+        value: from_lovelace(2_000_000),
+        datum: InlineDatum(future_request),
+        reference_script: None,
+      },
+    }
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    feeStateDatum,
+    Reject,
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase1Range,
+      outputs: [rejectStateOutput, refundOutput],
+      extra_signatories: ["owner"],
+      inputs: [feeStateInput, future_request_input],
+    },
+  )
+}
+
+test reject_missing_signature() fail {
+  // No owner signature
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    feeStateDatum,
+    Reject,
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase3Range,
+      outputs: [rejectStateOutput, refundOutput],
+      extra_signatories: [],
+      inputs: [feeStateInput, feeRequestInput],
+    },
+  )
+}
+
+test reject_root_changes() fail {
+  // Root must NOT change during reject
+  let bad_reject_output =
+    Output {
+      address: testScriptAddress,
+      value: testValue,
+      datum: InlineDatum(
+        StateDatum(
+          State {
+            owner: "owner",
+            root: "different_root_aaaaaaaaaaaaa",
+            max_fee: testFee,
+          },
+        ),
+      ),
+      reference_script: None,
+    }
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    feeStateDatum,
+    Reject,
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase3Range,
+      outputs: [bad_reject_output, refundOutput],
+      extra_signatories: ["owner"],
+      inputs: [feeStateInput, feeRequestInput],
+    },
+  )
+}
+
+test reject_wrong_refund() fail {
+  // Insufficient refund amount
+  let bad_refund =
+    Output {
+      ..refundOutput,
+      value: from_lovelace(500_000),
+    }
+  mpfCage.spend(
+    0,
+    testProcessTime,
+    testRetractTime,
+    feeStateDatum,
+    Reject,
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase3Range,
+      outputs: [rejectStateOutput, bad_refund],
+      extra_signatories: ["owner"],
+      inputs: [feeStateInput, feeRequestInput],
     },
   )
 }

--- a/validators/types.ak
+++ b/validators/types.ak
@@ -136,6 +136,7 @@ pub type MintRedeemer {
 /// | `Contribute`   | `RequestDatum`  | Anyone (permissionless) | Link a request to a State UTxO |
 /// | `Modify`       | `StateDatum`    | State owner             | Fold requests into MPF         |
 /// | `Retract`      | `RequestDatum`  | Request owner           | Reclaim an unprocessed request |
+/// | `Reject`       | `StateDatum`    | State owner             | Discard expired/dishonest reqs |
 ///
 /// ## Test Hints
 /// - Using `End` on a `RequestDatum` UTxO -> should fail (expects StateDatum)
@@ -188,6 +189,11 @@ pub type UpdateRedeemer {
   /// - Retract signed by someone else -> should fail
   /// - Retract on an already-processed request -> impossible (UTxO already consumed)
   Retract
+  /// Discard requests that are past their retract window (Phase 3) or have
+  /// a dishonest (future) `submitted_at` timestamp. Requires State datum.
+  /// The oracle keeps the fee and refunds the remaining lovelace.
+  /// The MPF root MUST NOT change during a Reject operation.
+  Reject
 }
 
 /// The state of a caged token, stored as inline datum.
@@ -325,6 +331,10 @@ pub type Request {
   /// The fee (in lovelace) the requester agrees to pay.
   /// Must match `state.max_fee` at Modify time.
   fee: Int,
+  /// The POSIXTime (in milliseconds) when the request was submitted.
+  /// Used for time-gated phase enforcement: Phase 1 (oracle-only),
+  /// Phase 2 (requester retract), Phase 3 (oracle reject/cleanup).
+  submitted_at: Int,
 }
 
 /// Datum for UTxOs locked at the cage script address.


### PR DESCRIPTION
## Summary

- Three exclusive time phases per request (Phase 1: oracle Modify, Phase 2: requester Retract, Phase 3: oracle Reject) enforced on-chain via `tx.validity_range`, preventing DDoS race conditions
- `Reject` redeemer for batch cleanup of expired/dishonest requests with on-chain refund verification
- `process_time` and `retract_time` as immutable validator parameters; `submitted_at` and `fee` fields in Request datum
- TypeScript type check CI job, fix pre-existing TS errors (`@types/node`, `Data` typing)
- Architecture docs updated with phase diagrams, Reject flow, migration, and 67 tests across 16 security categories

## Test plan

- [x] `aiken check` — 67/67 tests pass (55 cage + 12 lib), including 12 new phase/reject tests
- [x] `aiken build` — `plutus.json` regenerated with new validator params
- [x] `npx tsc --noEmit` — zero TypeScript errors
- [ ] CI passes (Aiken build + tests, TypeScript typecheck, E2E on Yaci DevKit)

Closes #8