### PR TITLE
feat: Lean 4 theorems for lib.ak token handling

### DIFF
--- a/lean/MpfsCage/Lib.lean
+++ b/lean/MpfsCage/Lib.lean
@@ -104,15 +104,23 @@ theorem quantity_present
 theorem quantity_wrong_policy
     (p p' : PolicyId) (a : AssetName) (q : Int)
     (hne : p ≠ p') :
-    quantity p a (fromAsset p' a q) = some q → False := by
-  simp [fromAsset, quantity, List.filter]
-  intro h
+    quantity p a (fromAsset p' a q) = none := by
+  simp only [fromAsset, quantity, List.filter]
   simp [show (p' == p) = false from by
-    simp [BEq.beq]; exact fun h => hne h.symm] at h
+    simp [BEq.beq]; exact fun h => hne h.symm]
+
+/-- Looking up with the wrong asset name returns `none`.
+    Mirrors Aiken test `quantity_wrong_asset`. -/
+theorem quantity_wrong_asset
+    (p : PolicyId) (a a' : AssetName) (q : Int)
+    (hne : a ≠ a') :
+    quantity p a (fromAsset p a' q) = none := by
+  simp only [fromAsset, quantity, List.filter]
+  simp [show (a' == a) = false from by
+    simp [BEq.beq]; exact fun h => hne h.symm]
 
 /-- Composing `valueFromToken` with `quantity` yields `some 1`.
-    Mirrors the combination of Aiken tests for `valueFromToken`
-    and `quantity`. -/
+    Mirrors Aiken test `quantity_valueFromToken`. -/
 theorem quantity_valueFromToken
     (p : PolicyId) (a : AssetName) :
     quantity p a (valueFromToken p a) = some 1 := by

--- a/lean/MpfsCage/Lib.lean
+++ b/lean/MpfsCage/Lib.lean
@@ -62,21 +62,44 @@ def quantity (p : PolicyId) (a : AssetName) (v : Value) : Option Int :=
 -- Theorems
 -- ============================================================
 
-/-- Round-trip: extracting the token from a single-token value
-    returns that token's asset name.
+/-- `valueFromToken` and `tokenFromValue` are inverses for single-token
+    values with a non-ADA policy (`p ≠ ""`).
+
+    This is the foundation of cage NFT identity: after minting via
+    `valueFromToken`, the cage validator uses `tokenFromValue` on spending
+    UTxOs to recover the token. If the round-trip failed, the validator
+    could not match a cage UTxO back to its token — Modify, Retract, and
+    End operations would all break.
+
     Mirrors Aiken test `tokenFromValue_roundtrip`. -/
 theorem valueFromToken_roundtrip
     (p : PolicyId) (a : AssetName) (hp : p ≠ "") :
     tokenFromValue (valueFromToken p a) = some a := by
   simp [valueFromToken, fromAsset, tokenFromValue, List.filter, hp]
 
-/-- ADA-only value (policy = "") yields `none`.
+/-- A value containing only ADA (the empty-string policy) has no
+    extractable token.
+
+    On Cardano, every UTxO carries ADA. The cage validator must
+    distinguish "ADA + one NFT" (a cage UTxO) from "ADA only" (not
+    a cage). Without this property, a plain ADA UTxO at the script
+    address could be mistaken for a cage, letting an attacker spend
+    it as if it held a token.
+
     Mirrors Aiken test `tokenFromValue_ada_only`. -/
 theorem tokenFromValue_ada_only (a : AssetName) (q : Int) :
     tokenFromValue (fromAsset "" a q) = none := by
   simp [fromAsset, tokenFromValue, List.filter]
 
-/-- Two different non-ADA policies yield `none`.
+/-- A value with two different non-ADA policies has no unambiguously
+    extractable token.
+
+    Cage UTxOs must hold exactly one NFT (under the cage policy). If
+    a UTxO somehow contained tokens from two policies, `tokenFromValue`
+    cannot decide which is the cage NFT, so it returns `none`. The
+    validator then rejects the transaction, preventing token confusion
+    between different cage instances or foreign policies.
+
     Mirrors Aiken test `tokenFromValue_multi_policy`. -/
 theorem tokenFromValue_multi_policy
     (p1 p2 : PolicyId) (a1 a2 : AssetName) (q1 q2 : Int)
@@ -84,7 +107,15 @@ theorem tokenFromValue_multi_policy
     tokenFromValue (⟨p1, a1, q1⟩ :: ⟨p2, a2, q2⟩ :: []) = none := by
   simp [tokenFromValue, List.filter, hp1, hp2]
 
-/-- Same policy, two assets yield `none`.
+/-- A value with two different asset names under the same policy has
+    no unambiguously extractable token.
+
+    Even within a single policy, each cage NFT has a unique asset name
+    (derived from its minting OutputReference). A UTxO holding two
+    assets under one policy is ambiguous — which token does this cage
+    belong to? Returning `none` forces the validator to reject, preventing
+    an attacker from bundling tokens to confuse Modify or End logic.
+
     Mirrors Aiken test `tokenFromValue_multi_asset`. -/
 theorem tokenFromValue_multi_asset
     (p : PolicyId) (a1 a2 : AssetName) (q1 q2 : Int)
@@ -92,14 +123,27 @@ theorem tokenFromValue_multi_asset
     tokenFromValue (⟨p, a1, q1⟩ :: ⟨p, a2, q2⟩ :: []) = none := by
   simp [tokenFromValue, List.filter, hp]
 
-/-- Looking up a token that is present returns its quantity.
+/-- Looking up a token that is present in a value returns its quantity.
+
+    This is the core of mint validation: `validateMint` checks
+    `quantity(policyId, mint, tokenId) == Some(1)` to ensure exactly
+    one token is minted. If `quantity` failed to find a present token,
+    valid minting transactions would be rejected.
+
     Mirrors Aiken test `quantity_present`. -/
 theorem quantity_present
     (p : PolicyId) (a : AssetName) (q : Int) :
     quantity p a (fromAsset p a q) = some q := by
   simp [fromAsset, quantity, List.filter]
 
-/-- Looking up with the wrong policy returns `none`.
+/-- Looking up a token under the wrong policy returns `none`.
+
+    Cage instances are isolated by policy ID (each cage script has its
+    own hash). A token minted under policy `p'` must not be visible
+    when querying policy `p`. Without this, an attacker could create
+    a cheap token under their own policy and have it pass the quantity
+    check of a different cage's validator.
+
     Mirrors Aiken test `quantity_wrong_policy`. -/
 theorem quantity_wrong_policy
     (p p' : PolicyId) (a : AssetName) (q : Int)
@@ -109,7 +153,14 @@ theorem quantity_wrong_policy
   simp [show (p' == p) = false from by
     simp [BEq.beq]; exact fun h => hne h.symm]
 
-/-- Looking up with the wrong asset name returns `none`.
+/-- Looking up a token with the wrong asset name returns `none`.
+
+    Within a cage policy, each NFT has a unique asset name derived from
+    its minting OutputReference. The quantity check must distinguish
+    between different tokens under the same policy — otherwise burning
+    token A could satisfy a check meant for token B, allowing an
+    attacker to destroy the wrong cage.
+
     Mirrors Aiken test `quantity_wrong_asset`. -/
 theorem quantity_wrong_asset
     (p : PolicyId) (a a' : AssetName) (q : Int)
@@ -119,7 +170,16 @@ theorem quantity_wrong_asset
   simp [show (a' == a) = false from by
     simp [BEq.beq]; exact fun h => hne h.symm]
 
-/-- Composing `valueFromToken` with `quantity` yields `some 1`.
+/-- The mint validation path works end-to-end: constructing a
+    single-token value with `valueFromToken` and then querying its
+    quantity yields exactly `some 1`.
+
+    This composes `valueFromToken` (used to build the expected mint
+    output) with `quantity` (used to verify the actual mint field).
+    `validateMint` relies on both — it constructs the expected value
+    and checks `quantity == Some(1)`. If the composition failed, no
+    minting transaction could ever pass validation.
+
     Mirrors Aiken test `quantity_valueFromToken`. -/
 theorem quantity_valueFromToken
     (p : PolicyId) (a : AssetName) :

--- a/lean/MpfsCage/Lib.lean
+++ b/lean/MpfsCage/Lib.lean
@@ -1,0 +1,119 @@
+/-!
+# MPFS Cage — Token Handling Logic
+
+Formal model of the token manipulation functions from the
+cardano-mpfs-onchain Aiken `lib.ak` module.
+
+## Functions Modelled
+
+- `fromAsset`: Construct a value with a single token entry.
+- `valueFromToken`: Construct a value with quantity 1 of a token.
+- `tokenFromValue`: Extract the single non-ADA token from a value.
+- `quantity`: Look up the quantity of a specific token in a value.
+
+## Design
+
+Values are modelled as flat association lists of `(PolicyId, AssetName, Int)`.
+This mirrors Aiken's nested `Dict<PolicyId, Dict<AssetName, Int>>` but
+flattened for proof simplicity — the theorems target individual function
+round-trips and look-ups, not the full dictionary algebra.
+-/
+
+abbrev PolicyId := String
+abbrev AssetName := String
+
+/-- A single entry in a value: policy, asset name, and quantity. -/
+structure TokenEntry where
+  policy : PolicyId
+  asset : AssetName
+  qty : Int
+  deriving DecidableEq, Repr
+
+/-- A value is a list of token entries. -/
+def Value := List TokenEntry
+
+/-- Construct a value with a single token entry. -/
+def fromAsset (p : PolicyId) (a : AssetName) (q : Int) : Value :=
+  [⟨p, a, q⟩]
+
+/-- Construct a value with exactly 1 of the specified token.
+    Mirrors Aiken's `from_asset(policyId, assetName, 1)`. -/
+def valueFromToken (p : PolicyId) (a : AssetName) : Value :=
+  fromAsset p a 1
+
+/-- Extract the single non-ADA token's asset name from a value.
+    Returns `none` unless there is exactly one entry with a
+    non-empty (non-ADA) policy ID. Mirrors Aiken's `tokenFromValue`. -/
+def tokenFromValue (v : Value) : Option AssetName :=
+  match v.filter (fun e => e.policy ≠ "") with
+  | [e] => some e.asset
+  | _   => none
+
+/-- Look up the quantity of a specific token in a value.
+    Returns `some qty` if exactly one entry matches the given
+    policy and asset name, `none` otherwise.
+    Mirrors Aiken's `quantity(policyId, value, TokenId)`. -/
+def quantity (p : PolicyId) (a : AssetName) (v : Value) : Option Int :=
+  match v.filter (fun e => e.policy == p && e.asset == a) with
+  | [e] => some e.qty
+  | _   => none
+
+-- ============================================================
+-- Theorems
+-- ============================================================
+
+/-- Round-trip: extracting the token from a single-token value
+    returns that token's asset name.
+    Mirrors Aiken test `tokenFromValue_roundtrip`. -/
+theorem valueFromToken_roundtrip
+    (p : PolicyId) (a : AssetName) (hp : p ≠ "") :
+    tokenFromValue (valueFromToken p a) = some a := by
+  simp [valueFromToken, fromAsset, tokenFromValue, List.filter, hp]
+
+/-- ADA-only value (policy = "") yields `none`.
+    Mirrors Aiken test `tokenFromValue_ada_only`. -/
+theorem tokenFromValue_ada_only (a : AssetName) (q : Int) :
+    tokenFromValue (fromAsset "" a q) = none := by
+  simp [fromAsset, tokenFromValue, List.filter]
+
+/-- Two different non-ADA policies yield `none`.
+    Mirrors Aiken test `tokenFromValue_multi_policy`. -/
+theorem tokenFromValue_multi_policy
+    (p1 p2 : PolicyId) (a1 a2 : AssetName) (q1 q2 : Int)
+    (hp1 : p1 ≠ "") (hp2 : p2 ≠ "") :
+    tokenFromValue (⟨p1, a1, q1⟩ :: ⟨p2, a2, q2⟩ :: []) = none := by
+  simp [tokenFromValue, List.filter, hp1, hp2]
+
+/-- Same policy, two assets yield `none`.
+    Mirrors Aiken test `tokenFromValue_multi_asset`. -/
+theorem tokenFromValue_multi_asset
+    (p : PolicyId) (a1 a2 : AssetName) (q1 q2 : Int)
+    (hp : p ≠ "") :
+    tokenFromValue (⟨p, a1, q1⟩ :: ⟨p, a2, q2⟩ :: []) = none := by
+  simp [tokenFromValue, List.filter, hp]
+
+/-- Looking up a token that is present returns its quantity.
+    Mirrors Aiken test `quantity_present`. -/
+theorem quantity_present
+    (p : PolicyId) (a : AssetName) (q : Int) :
+    quantity p a (fromAsset p a q) = some q := by
+  simp [fromAsset, quantity, List.filter]
+
+/-- Looking up with the wrong policy returns `none`.
+    Mirrors Aiken test `quantity_wrong_policy`. -/
+theorem quantity_wrong_policy
+    (p p' : PolicyId) (a : AssetName) (q : Int)
+    (hne : p ≠ p') :
+    quantity p a (fromAsset p' a q) = some q → False := by
+  simp [fromAsset, quantity, List.filter]
+  intro h
+  simp [show (p' == p) = false from by
+    simp [BEq.beq]; exact fun h => hne h.symm] at h
+
+/-- Composing `valueFromToken` with `quantity` yields `some 1`.
+    Mirrors the combination of Aiken tests for `valueFromToken`
+    and `quantity`. -/
+theorem quantity_valueFromToken
+    (p : PolicyId) (a : AssetName) :
+    quantity p a (valueFromToken p a) = some 1 := by
+  simp [valueFromToken, quantity_present]

--- a/lean/lakefile.lean
+++ b/lean/lakefile.lean
@@ -8,4 +8,4 @@ package mpfsCage where
 
 @[default_target]
 lean_lib MpfsCage where
-  roots := #[`MpfsCage.Phases]
+  roots := #[`MpfsCage.Phases, `MpfsCage.Lib]

--- a/validators/lib.props.ak
+++ b/validators/lib.props.ak
@@ -28,9 +28,16 @@ use lib.{TokenId, quantity, tokenFromValue, valueFromToken}
 
 /// **Lean: valueFromToken_roundtrip**
 ///
-/// Extracting the token from a single-token value returns that token's
-/// asset name. The `p ≠ ""` precondition (non-ADA policy) is guaranteed
-/// by using 28-byte policy IDs.
+/// `tokenFromValue(valueFromToken(pid, tid))` always returns `Some(tid)`
+/// for any non-ADA policy ID.
+///
+/// After minting, the cage validator uses `tokenFromValue` on spending UTxOs
+/// to recover the cage NFT identity. If the round-trip broke, the validator
+/// could not match a cage UTxO back to its token — Modify, Retract, End,
+/// and Reject operations would all fail to identify the cage.
+///
+/// The `p ≠ ""` precondition (non-ADA policy) is guaranteed by using
+/// 28-byte policy IDs, which can never equal the empty bytestring.
 test prop_valueFromToken_roundtrip(
   params via fuzz.tuple(fuzz.bytearray_fixed(28), fuzz.bytearray_fixed(32)),
 ) {
@@ -41,8 +48,14 @@ test prop_valueFromToken_roundtrip(
 
 /// **Lean: tokenFromValue_ada_only**
 ///
-/// An ADA-only value (policy = "") yields None. The cage validator must
-/// reject UTxOs that contain no native token.
+/// A value containing only ADA (the empty-string policy) has no extractable
+/// token — `tokenFromValue` returns `None`.
+///
+/// Every Cardano UTxO carries ADA. The cage validator must distinguish
+/// "ADA + one NFT" (a valid cage UTxO) from "ADA only" (not a cage).
+/// If this property failed, a plain ADA UTxO sitting at the script address
+/// could be mistaken for a cage, letting an attacker spend it via Modify
+/// or End as if it held a real token.
 test prop_tokenFromValue_ada_only(
   params via fuzz.tuple(fuzz.bytearray_fixed(32), fuzz.int_between(1, 1_000_000)),
 ) {
@@ -53,7 +66,16 @@ test prop_tokenFromValue_ada_only(
 
 /// **Lean: quantity_present**
 ///
-/// Looking up a token that is present returns its quantity.
+/// `quantity(p, fromAsset(p, a, q), TokenId{a})` always returns `Some(q)`.
+///
+/// This is the core of mint validation: `validateMint` checks
+/// `quantity(policyId, mint, tokenId) == Some(1)` to ensure exactly one
+/// token is minted, and `End` checks `quantity == Some(-1)` for burns.
+/// If `quantity` could not find a token that is actually present, valid
+/// minting and burning transactions would be rejected.
+///
+/// The fuzzer covers both positive and negative quantities to exercise
+/// the minting (positive) and burning (negative) paths.
 test prop_quantity_present(
   params via fuzz.tuple(
     fuzz.tuple(fuzz.bytearray_fixed(28), fuzz.bytearray_fixed(32)),
@@ -68,13 +90,17 @@ test prop_quantity_present(
 
 /// **Lean: quantity_wrong_policy**
 ///
-/// Looking up with a different policy returns None. Policy ID is the
-/// first level of the Value map — a mismatch means the token doesn't
-/// exist under that policy.
+/// Looking up a token under a different policy always returns `None`.
 ///
-/// Two independently-fuzzed 28-byte policy IDs are extremely unlikely
-/// to collide (2^224 space), satisfying the `p ≠ p'` precondition.
-/// The `fail once` directive confirms that collisions are rejected.
+/// Cage instances are isolated by policy ID (each cage script has its own
+/// hash). A token minted under policy `p'` must not be visible when querying
+/// policy `p`. Without this isolation, an attacker could mint a cheap token
+/// under their own policy and have it pass another cage's quantity check.
+///
+/// Two independently-fuzzed 28-byte policy IDs are extremely unlikely to
+/// collide (2^224 space), satisfying the Lean `p ≠ p'` precondition.
+/// The `fail once` directive confirms that collisions are rejected by the
+/// fuzzer — the test expects the equality to fail on the first try.
 test prop_quantity_wrong_policy(
   params via fuzz.tuple(
     fuzz.tuple(fuzz.bytearray_fixed(28), fuzz.bytearray_fixed(28)),
@@ -89,11 +115,17 @@ test prop_quantity_wrong_policy(
 
 /// **Lean: quantity_wrong_asset**
 ///
-/// Looking up with a different asset name returns None. Even if the
-/// policy matches, the specific token must also match.
+/// Looking up a token with a different asset name always returns `None`,
+/// even when the policy matches.
 ///
-/// Two independently-fuzzed 32-byte asset names are extremely unlikely
-/// to collide, satisfying the `a ≠ a'` precondition.
+/// Within a cage policy, each NFT has a unique asset name derived from its
+/// minting OutputReference via SHA2-256. The quantity check must distinguish
+/// between different tokens under the same policy — otherwise burning token
+/// A could satisfy a check meant for token B, letting an attacker destroy
+/// the wrong cage while keeping the intended target alive.
+///
+/// Two independently-fuzzed 32-byte asset names are extremely unlikely to
+/// collide, satisfying the Lean `a ≠ a'` precondition.
 test prop_quantity_wrong_asset(
   params via fuzz.tuple(
     fuzz.tuple(fuzz.bytearray_fixed(28), fuzz.bytearray_fixed(32)),
@@ -108,9 +140,13 @@ test prop_quantity_wrong_asset(
 
 /// **Lean: quantity_valueFromToken**
 ///
-/// Composing `valueFromToken` with `quantity` yields `Some(1)`.
-/// This ensures the mint validation path works end-to-end:
-/// construct a single-token value, then verify quantity is exactly 1.
+/// `quantity(p, valueFromToken(p, tid), tid)` always returns `Some(1)`.
+///
+/// This is the end-to-end mint validation path: `validateMint` constructs
+/// the expected output value via `valueFromToken` and then verifies the
+/// actual mint field via `quantity == Some(1)`. This theorem proves the
+/// two functions compose correctly — without it, no minting transaction
+/// could ever pass validation, and no new cages could be created.
 test prop_quantity_valueFromToken(
   params via fuzz.tuple(fuzz.bytearray_fixed(28), fuzz.bytearray_fixed(32)),
 ) {

--- a/validators/lib.props.ak
+++ b/validators/lib.props.ak
@@ -1,0 +1,120 @@
+/// Token handling property tests (fuzz) — mirror Lean theorems in MpfsCage/Lib.lean.
+///
+/// These property tests verify the token manipulation functions from `lib.ak`
+/// that the cage validator relies on for token identification and extraction.
+///
+/// Each property mirrors a machine-checked Lean 4 theorem. The Lean proofs
+/// provide mathematical certainty; the fuzz tests validate the Aiken
+/// implementation matches the formal specification.
+///
+/// ## Functions Under Test
+///
+/// - `valueFromToken` / `tokenFromValue`: Construct a single-token value and
+///   extract the token back. Round-trip correctness ensures the cage can always
+///   identify its own NFTs.
+///
+/// - `quantity`: Look up a specific token's quantity in a value. Used in mint
+///   validation to enforce exactly-one-token rules.
+///
+/// ## Fuzzer Design
+///
+/// Policy IDs and asset names are fuzzed as fixed-length bytearrays (28 bytes
+/// for policy IDs, matching Cardano's script hash length; 32 bytes for asset
+/// names, matching SHA2-256 output). Non-empty policy IDs are guaranteed by
+/// the fixed length, satisfying the `p ≠ ""` precondition.
+use aiken/fuzz
+use cardano/assets.{from_asset}
+use lib.{TokenId, quantity, tokenFromValue, valueFromToken}
+
+/// **Lean: valueFromToken_roundtrip**
+///
+/// Extracting the token from a single-token value returns that token's
+/// asset name. The `p ≠ ""` precondition (non-ADA policy) is guaranteed
+/// by using 28-byte policy IDs.
+test prop_valueFromToken_roundtrip(
+  params via fuzz.tuple(fuzz.bytearray_fixed(28), fuzz.bytearray_fixed(32)),
+) {
+  let (pid, asset) = params
+  let tid = TokenId { assetName: asset }
+  tokenFromValue(valueFromToken(pid, tid)) == Some(tid)
+}
+
+/// **Lean: tokenFromValue_ada_only**
+///
+/// An ADA-only value (policy = "") yields None. The cage validator must
+/// reject UTxOs that contain no native token.
+test prop_tokenFromValue_ada_only(
+  params via fuzz.tuple(fuzz.bytearray_fixed(32), fuzz.int_between(1, 1_000_000)),
+) {
+  let (asset, qty) = params
+  let v = from_asset("", asset, qty)
+  tokenFromValue(v) == None
+}
+
+/// **Lean: quantity_present**
+///
+/// Looking up a token that is present returns its quantity.
+test prop_quantity_present(
+  params via fuzz.tuple(
+    fuzz.tuple(fuzz.bytearray_fixed(28), fuzz.bytearray_fixed(32)),
+    fuzz.int_between(-1_000_000, 1_000_000),
+  ),
+) {
+  let ((pid, asset), qty) = params
+  let tid = TokenId { assetName: asset }
+  let v = from_asset(pid, asset, qty)
+  quantity(pid, v, tid) == Some(qty)
+}
+
+/// **Lean: quantity_wrong_policy**
+///
+/// Looking up with a different policy returns None. Policy ID is the
+/// first level of the Value map — a mismatch means the token doesn't
+/// exist under that policy.
+///
+/// Two independently-fuzzed 28-byte policy IDs are extremely unlikely
+/// to collide (2^224 space), satisfying the `p ≠ p'` precondition.
+/// The `fail once` directive confirms that collisions are rejected.
+test prop_quantity_wrong_policy(
+  params via fuzz.tuple(
+    fuzz.tuple(fuzz.bytearray_fixed(28), fuzz.bytearray_fixed(28)),
+    fuzz.tuple(fuzz.bytearray_fixed(32), fuzz.int_between(1, 1_000_000)),
+  ),
+) fail once {
+  let ((pid, other_pid), (asset, qty)) = params
+  let tid = TokenId { assetName: asset }
+  let v = from_asset(other_pid, asset, qty)
+  quantity(pid, v, tid) == Some(qty)
+}
+
+/// **Lean: quantity_wrong_asset**
+///
+/// Looking up with a different asset name returns None. Even if the
+/// policy matches, the specific token must also match.
+///
+/// Two independently-fuzzed 32-byte asset names are extremely unlikely
+/// to collide, satisfying the `a ≠ a'` precondition.
+test prop_quantity_wrong_asset(
+  params via fuzz.tuple(
+    fuzz.tuple(fuzz.bytearray_fixed(28), fuzz.bytearray_fixed(32)),
+    fuzz.tuple(fuzz.bytearray_fixed(32), fuzz.int_between(1, 1_000_000)),
+  ),
+) fail once {
+  let ((pid, asset), (other_asset, qty)) = params
+  let tid = TokenId { assetName: asset }
+  let v = from_asset(pid, other_asset, qty)
+  quantity(pid, v, tid) == Some(qty)
+}
+
+/// **Lean: quantity_valueFromToken**
+///
+/// Composing `valueFromToken` with `quantity` yields `Some(1)`.
+/// This ensures the mint validation path works end-to-end:
+/// construct a single-token value, then verify quantity is exactly 1.
+test prop_quantity_valueFromToken(
+  params via fuzz.tuple(fuzz.bytearray_fixed(28), fuzz.bytearray_fixed(32)),
+) {
+  let (pid, asset) = params
+  let tid = TokenId { assetName: asset }
+  quantity(pid, valueFromToken(pid, tid), tid) == Some(1)
+}

--- a/validators/lib.tests.ak
+++ b/validators/lib.tests.ak
@@ -149,3 +149,11 @@ test quantity_wrong_asset() {
   let v = from_asset(q_policy, "other_asset", 1)
   quantity(q_policy, v, q_token) == None
 }
+
+/// Composing valueFromToken with quantity yields Some(1).
+/// Mirrors Lean theorem `quantity_valueFromToken`.
+test quantity_valueFromToken() {
+  let pid = "my_policy"
+  let tid = TokenId { assetName: "my_asset" }
+  quantity(pid, valueFromToken(pid, tid), tid) == Some(1)
+}


### PR DESCRIPTION
## Summary

- Add `lean/MpfsCage/Lib.lean` with formal model of `tokenFromValue`, `valueFromToken`, `quantity`, and `fromAsset`
- 7 machine-checked theorems mirroring Aiken unit tests from `validators/lib.ak`
- Update `lakefile.lean` roots to include the new module

## Theorems

| Theorem | Mirrors |
|---------|---------|
| `valueFromToken_roundtrip` | `tokenFromValue(valueFromToken(pid, tid)) = some tid` |
| `tokenFromValue_ada_only` | ADA-only value returns `none` |
| `tokenFromValue_multi_policy` | Two non-ADA policies → `none` |
| `tokenFromValue_multi_asset` | Same policy, two assets → `none` |
| `quantity_present` | `quantity p a (fromAsset p a q) = some q` |
| `quantity_wrong_policy` | Wrong policy → `none` |
| `quantity_valueFromToken` | `quantity p a (valueFromToken p a) = some 1` |

## Test plan

- [ ] `lake build` succeeds (all 7 proofs type-check)
- [ ] Existing `Phases.lean` still builds (regression)
- [ ] CI passes