### PR TITLE
Add lean4 compiler to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,7 +85,10 @@
         };
 
         devShells.default = pkgs.mkShell {
-          packages = [ pkgs.aiken ];
+          packages = [
+            pkgs.aiken
+            pkgs.lean4
+          ];
         };
       }
     );


### PR DESCRIPTION
## Summary
- Add `pkgs.lean4` to the nix dev shell packages

## Test plan
- [x] `nix develop --command lean --version` → Lean 4.27.0