### PR TITLE
docs: update mkdocs after time-params-to-datum refactor

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -68,7 +68,8 @@ stateDiagram-v2
 Each request passes through three exclusive time phases,
 enforced on-chain via `tx.validity_range`. The phase boundaries
 are determined by the request's `submitted_at` timestamp and the
-validator's immutable `process_time` and `retract_time` parameters.
+State datum's `process_time` and `retract_time` fields (set at
+mint time and enforced immutable across Modify/Reject operations).
 
 ```mermaid
 gantt
@@ -150,7 +151,7 @@ sequenceDiagram
 ## Security Properties
 
 The validators enforce invariants across 16 categories, each
-verified by the inline test suite (67 tests):
+verified by the inline test suite (80 tests):
 
 1. **Ownership** — only the oracle (token owner) can modify, reject, or destroy a token.
 2. **Integrity** — every MPF modification carries a cryptographic proof

--- a/docs/architecture/properties.md
+++ b/docs/architecture/properties.md
@@ -12,7 +12,7 @@ and verified by the inline test suite in
 [`cage.ak`](https://github.com/cardano-foundation/cardano-mpfs-onchain/blob/main/validators/cage.ak)
 and
 [`lib.ak`](https://github.com/cardano-foundation/cardano-mpfs-onchain/blob/main/validators/lib.ak).
-Run `aiken check` (or `just test`) to check all 67 tests.
+Run `aiken check` (or `just test`) to check all 80 tests.
 
 ---
 
@@ -266,8 +266,9 @@ extraction fails and the validator rejects.
 
 **Invariant:** Each request passes through three exclusive time
 phases. The validator enforces phase boundaries using
-`tx.validity_range` and the immutable `process_time` / `retract_time`
-parameters. No operation can execute outside its designated phase.
+`tx.validity_range` and the State datum's `process_time` /
+`retract_time` fields (set at mint time, enforced immutable).
+No operation can execute outside its designated phase.
 
 ```
 submitted_at          + process_time       + process_time + retract_time
@@ -360,4 +361,4 @@ The old token must be burned (-1) in the same transaction.
 | 14 | Reject (DDoS protection) | 7 |
 | 15 | Fee enforcement | 6 |
 | 16 | Migration | 4 |
-| | **Total** | **67** |
+| | **Total** | **80** |

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,4 +23,4 @@ requesters, and a Reject mechanism enables DDoS protection.
 - [Validators](architecture/validators.md) — minting policy and spending validator logic
 - [Types & Encodings](architecture/types.md) — datum, redeemer, and operation structures
 - [Proof System](architecture/proofs.md) — MPF proof format, verification, and performance
-- [Security Properties](architecture/properties.md) — 16 categories verified by 67 tests
+- [Security Properties](architecture/properties.md) — 16 categories verified by 80 tests


### PR DESCRIPTION
## Summary

- Validator params section: 3 → 1 (version only), added admonition about time params in datum
- State type: added process_time/retract_time fields and descriptions
- Retract redeemer: now takes OutputReference, uses reference inputs
- Modify/Reject: added time param immutability enforcement
- Test count: 67 → 80 across all pages