### PR TITLE
fix: migrate to mkdocs-deploy wrapper

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -21,4 +21,4 @@ jobs:
       - uses: paolino/dev-assets/setup-nix@v0.0.1
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix develop github:paolino/dev-assets?dir=mkdocs -c mkdocs gh-deploy --force
+      - run: nix develop github:paolino/dev-assets?dir=mkdocs -c mkdocs-deploy --force


### PR DESCRIPTION
## Summary
- Replace `mkdocs gh-deploy` with `mkdocs-deploy` wrapper from dev-assets
- The wrapper cleans up `site/` after deployment, preventing read-only nix store files from blocking CI checkouts

Closes #32