### PR TITLE
fix: fair fee model (tx.fee + tip)

### DIFF
--- a/e2e/src/cage.ts
+++ b/e2e/src/cage.ts
@@ -456,24 +456,21 @@ class Cage implements PromiseLike<void> {
 
   /**
    * Build a transaction with conservation-exact refunds.
-   * Two-pass: first estimate the fee with a dummy build, then rebuild
-   * with refund amounts that satisfy the conservation equation.
-   * Iterates until the fee stabilizes (max 5 attempts).
+   *
+   * Uses a generous fee overestimate set via setMinFee(). The Cardano
+   * ledger only requires tx.fee >= min_fee, so overpaying is valid —
+   * the excess goes to the treasury. The refund outputs are computed
+   * based on this overestimate, and setMinFee() ensures the tx body
+   * carries that fee during script evaluation.
    */
   private async buildWithConservation(
     build: (estimatedFee: bigint) => ReturnType<LucidEvolution["newTx"]>,
   ): Promise<Awaited<ReturnType<ReturnType<LucidEvolution["newTx"]>["complete"]>>> {
-    let fee = 300_000n; // initial estimate
-    for (let i = 0; i < 5; i++) {
-      const txBuilder = build(fee);
-      const tx = await txBuilder.complete(COMPLETE_OPTS);
-      const actualFee = BigInt(tx.toTransaction().body().fee());
-      if (actualFee === fee) return tx;
-      fee = actualFee;
-    }
-    // Use last estimate
-    const txBuilder = build(fee);
-    return txBuilder.complete(COMPLETE_OPTS);
+    // Generous overestimate: scripts see this fee during evaluation
+    // and the ledger accepts it because fee >= min_fee.
+    const overestimatedFee = 500_000n;
+    const txBuilder = build(overestimatedFee);
+    return txBuilder.setMinFee(overestimatedFee).complete(COMPLETE_OPTS);
   }
 
   private async submitAndWait(

--- a/e2e/src/cage.ts
+++ b/e2e/src/cage.ts
@@ -35,7 +35,7 @@ export type Validator = ReturnType<
 interface PendingRequest {
   utxo: UTxO;
   datum: string;
-  fee: bigint;
+  tip: bigint;
   lovelace: bigint;
   submittedAt: bigint;
 }
@@ -69,7 +69,7 @@ class Cage implements PromiseLike<void> {
   private unit = "";
   private stateUtxo: UTxO | undefined;
   private root = EMPTY_ROOT;
-  private maxFee = 0n;
+  private tip = 0n;
   private processTime: bigint;
   private retractTime: bigint;
   private pendingRequests: PendingRequest[] = [];
@@ -108,12 +108,12 @@ class Cage implements PromiseLike<void> {
 
   // --- Public DSL methods ---
 
-  mint(opts?: { maxFee?: bigint }): this {
+  mint(opts?: { tip?: bigint }): this {
     this.chain = this.chain.then(() => this.doMint(opts));
     return this;
   }
 
-  request(key: string, value: string, opts?: { fee?: bigint }): this {
+  request(key: string, value: string, opts?: { tip?: bigint }): this {
     this.chain = this.chain.then(() =>
       this.doRequest(key, value, false, opts),
     );
@@ -123,7 +123,7 @@ class Cage implements PromiseLike<void> {
   deleteRequest(
     key: string,
     value: string,
-    opts?: { fee?: bigint },
+    opts?: { tip?: bigint },
   ): this {
     this.chain = this.chain.then(() =>
       this.doRequest(key, value, true, opts),
@@ -161,8 +161,8 @@ class Cage implements PromiseLike<void> {
 
   // --- Private step implementations ---
 
-  private async doMint(opts?: { maxFee?: bigint }): Promise<void> {
-    this.maxFee = opts?.maxFee ?? 0n;
+  private async doMint(opts?: { tip?: bigint }): Promise<void> {
+    this.tip = opts?.tip ?? 0n;
 
     const utxos = await this.lucid.wallet().getUtxos();
     expect(utxos.length).toBeGreaterThan(0);
@@ -178,7 +178,7 @@ class Cage implements PromiseLike<void> {
     const datum = encodeStateDatum(
       this.ownerKeyHash,
       EMPTY_ROOT,
-      this.maxFee,
+      this.tip,
       this.processTime,
       this.retractTime,
     );
@@ -205,9 +205,9 @@ class Cage implements PromiseLike<void> {
     key: string,
     value: string,
     isDelete: boolean,
-    opts?: { fee?: bigint },
+    opts?: { tip?: bigint },
   ): Promise<void> {
-    const fee = opts?.fee ?? 0n;
+    const tip = opts?.tip ?? 0n;
     const lovelace = 2_000_000n;
     const submittedAt = BigInt(Date.now()) + onChainTimeOffset;
     const encode = isDelete
@@ -218,7 +218,7 @@ class Cage implements PromiseLike<void> {
       this.ownerKeyHash,
       key,
       value,
-      fee,
+      tip,
       submittedAt,
     );
 
@@ -248,7 +248,7 @@ class Cage implements PromiseLike<void> {
     this.pendingRequests.push({
       utxo: requestUtxo!,
       datum,
-      fee,
+      tip,
       lovelace,
       submittedAt,
     });
@@ -261,39 +261,55 @@ class Cage implements PromiseLike<void> {
     const newDatum = encodeStateDatum(
       this.ownerKeyHash,
       newRoot,
-      this.maxFee,
+      this.tip,
       this.processTime,
       this.retractTime,
     );
 
     const now = BigInt(Date.now());
+    const n = BigInt(this.pendingRequests.length);
+    const totalInputLovelace = this.pendingRequests.reduce(
+      (sum, r) => sum + r.lovelace,
+      0n,
+    );
 
-    let txBuilder = this.lucid
-      .newTx()
-      .validFrom(Number(now))
-      .validTo(Number(now + 60_000n))
-      .collectFrom([this.stateUtxo!], modifyRedeemer)
-      .collectFrom(
-        this.pendingRequests.map((r) => r.utxo),
-        contributeRedeemer,
-      )
-      .pay.ToContract(
-        this.validator.scriptAddress,
-        { kind: "inline", value: newDatum },
-        { [this.unit]: 1n, lovelace: 2_000_000n },
-      );
+    // Two-pass: estimate fee, then set exact refunds
+    const tx = await this.buildWithConservation(
+      (estimatedFee: bigint) => {
+        const totalRefund = totalInputLovelace - estimatedFee - n * this.tip;
+        const perRequest = n > 0n ? totalRefund / n : 0n;
+        const remainder = n > 0n ? totalRefund % n : 0n;
 
-    // Refund each requester
-    for (const req of this.pendingRequests) {
-      txBuilder = txBuilder.pay.ToAddress(this.walletAddress, {
-        lovelace: req.lovelace - req.fee,
-      });
-    }
+        let txBuilder = this.lucid
+          .newTx()
+          .validFrom(Number(now))
+          .validTo(Number(now + 60_000n))
+          .collectFrom([this.stateUtxo!], modifyRedeemer)
+          .collectFrom(
+            this.pendingRequests.map((r) => r.utxo),
+            contributeRedeemer,
+          )
+          .pay.ToContract(
+            this.validator.scriptAddress,
+            { kind: "inline", value: newDatum },
+            { [this.unit]: 1n, lovelace: 2_000_000n },
+          );
 
-    const tx = await txBuilder
-      .attach.SpendingValidator(this.validator.spendValidator)
-      .addSignerKey(this.ownerKeyHash)
-      .complete(COMPLETE_OPTS);
+        // Refund each requester with conservation-exact amounts
+        this.pendingRequests.forEach((req, i) => {
+          const refund = perRequest + (BigInt(i) === 0n ? remainder : 0n);
+          if (refund > 0n) {
+            txBuilder = txBuilder.pay.ToAddress(this.walletAddress, {
+              lovelace: refund,
+            });
+          }
+        });
+
+        return txBuilder
+          .attach.SpendingValidator(this.validator.spendValidator)
+          .addSignerKey(this.ownerKeyHash);
+      },
+    );
 
     await this.submitAndWait(tx);
 
@@ -317,7 +333,7 @@ class Cage implements PromiseLike<void> {
     const datum = encodeStateDatum(
       this.ownerKeyHash,
       this.root,
-      this.maxFee,
+      this.tip,
       this.processTime,
       this.retractTime,
     );
@@ -358,42 +374,55 @@ class Cage implements PromiseLike<void> {
     const sameDatum = encodeStateDatum(
       this.ownerKeyHash,
       this.root,
-      this.maxFee,
+      this.tip,
       this.processTime,
       this.retractTime,
     );
 
     const now = BigInt(Date.now());
+    const n = BigInt(this.pendingRequests.length);
+    const totalInputLovelace = this.pendingRequests.reduce(
+      (sum, r) => sum + r.lovelace,
+      0n,
+    );
 
-    let txBuilder = this.lucid
-      .newTx()
-      .validFrom(Number(now))
-      .validTo(Number(now + 60_000n))
-      .collectFrom([this.stateUtxo!], rejectRedeemer)
-      .collectFrom(
-        this.pendingRequests.map((r) => r.utxo),
-        contributeRedeemer,
-      )
-      .pay.ToContract(
-        this.validator.scriptAddress,
-        { kind: "inline", value: sameDatum },
-        { [this.unit]: 1n, lovelace: 2_000_000n },
-      );
+    // Two-pass: estimate fee, then set exact refunds
+    const tx = await this.buildWithConservation(
+      (estimatedFee: bigint) => {
+        const totalRefund = totalInputLovelace - estimatedFee - n * this.tip;
+        const perRequest = n > 0n ? totalRefund / n : 0n;
+        const remainder = n > 0n ? totalRefund % n : 0n;
 
-    // Refund each requester (lovelace minus fee)
-    for (const req of this.pendingRequests) {
-      const refund = req.lovelace - req.fee;
-      if (refund > 0n) {
-        txBuilder = txBuilder.pay.ToAddress(this.walletAddress, {
-          lovelace: refund,
+        let txBuilder = this.lucid
+          .newTx()
+          .validFrom(Number(now))
+          .validTo(Number(now + 60_000n))
+          .collectFrom([this.stateUtxo!], rejectRedeemer)
+          .collectFrom(
+            this.pendingRequests.map((r) => r.utxo),
+            contributeRedeemer,
+          )
+          .pay.ToContract(
+            this.validator.scriptAddress,
+            { kind: "inline", value: sameDatum },
+            { [this.unit]: 1n, lovelace: 2_000_000n },
+          );
+
+        // Refund each requester with conservation-exact amounts
+        this.pendingRequests.forEach((req, i) => {
+          const refund = perRequest + (BigInt(i) === 0n ? remainder : 0n);
+          if (refund > 0n) {
+            txBuilder = txBuilder.pay.ToAddress(this.walletAddress, {
+              lovelace: refund,
+            });
+          }
         });
-      }
-    }
 
-    const tx = await txBuilder
-      .attach.SpendingValidator(this.validator.spendValidator)
-      .addSignerKey(this.ownerKeyHash)
-      .complete(COMPLETE_OPTS);
+        return txBuilder
+          .attach.SpendingValidator(this.validator.spendValidator)
+          .addSignerKey(this.ownerKeyHash);
+      },
+    );
 
     await this.submitAndWait(tx);
 
@@ -424,6 +453,28 @@ class Cage implements PromiseLike<void> {
   }
 
   // --- Helpers ---
+
+  /**
+   * Build a transaction with conservation-exact refunds.
+   * Two-pass: first estimate the fee with a dummy build, then rebuild
+   * with refund amounts that satisfy the conservation equation.
+   * Iterates until the fee stabilizes (max 5 attempts).
+   */
+  private async buildWithConservation(
+    build: (estimatedFee: bigint) => ReturnType<LucidEvolution["newTx"]>,
+  ): Promise<Awaited<ReturnType<ReturnType<LucidEvolution["newTx"]>["complete"]>>> {
+    let fee = 300_000n; // initial estimate
+    for (let i = 0; i < 5; i++) {
+      const txBuilder = build(fee);
+      const tx = await txBuilder.complete(COMPLETE_OPTS);
+      const actualFee = BigInt(tx.toTransaction().body().fee());
+      if (actualFee === fee) return tx;
+      fee = actualFee;
+    }
+    // Use last estimate
+    const txBuilder = build(fee);
+    return txBuilder.complete(COMPLETE_OPTS);
+  }
 
   private async submitAndWait(
     txBuilder: Awaited<ReturnType<ReturnType<LucidEvolution["newTx"]>["complete"]>>,

--- a/e2e/src/codec.ts
+++ b/e2e/src/codec.ts
@@ -1,16 +1,16 @@
 import { Constr, Data, type UTxO } from "@lucid-evolution/lucid";
 
 // CageDatum = RequestDatum(Request) | StateDatum(State)
-// StateDatum is constructor index 1, State has fields { owner, root, max_fee, process_time, retract_time }
+// StateDatum is constructor index 1, State has fields { owner, root, tip, process_time, retract_time }
 export function encodeStateDatum(
   owner: string,
   root: string,
-  maxFee: bigint = 0n,
+  tip: bigint = 0n,
   processTime: bigint = 60_000n,
   retractTime: bigint = 60_000n,
 ): string {
   return Data.to(
-    new Constr(1, [new Constr(0, [owner, root, maxFee, processTime, retractTime])]),
+    new Constr(1, [new Constr(0, [owner, root, tip, processTime, retractTime])]),
   );
 }
 
@@ -72,7 +72,7 @@ export function encodeRequestDatum(
   ownerHash: string,
   key: string,
   value: string,
-  fee: bigint = 0n,
+  tip: bigint = 0n,
   submittedAt: bigint = 0n,
 ): string {
   const tokenId = new Constr(0, [assetName]);
@@ -82,7 +82,7 @@ export function encodeRequestDatum(
     ownerHash,
     key,
     operation,
-    fee,
+    tip,
     submittedAt,
   ]);
   return Data.to(new Constr(0, [request]));
@@ -94,7 +94,7 @@ export function encodeDeleteRequestDatum(
   ownerHash: string,
   key: string,
   value: string,
-  fee: bigint = 0n,
+  tip: bigint = 0n,
   submittedAt: bigint = 0n,
 ): string {
   const tokenId = new Constr(0, [assetName]);
@@ -104,7 +104,7 @@ export function encodeDeleteRequestDatum(
     ownerHash,
     key,
     operation,
-    fee,
+    tip,
     submittedAt,
   ]);
   return Data.to(new Constr(0, [request]));

--- a/e2e/src/migration.test.ts
+++ b/e2e/src/migration.test.ts
@@ -53,8 +53,8 @@ describe("MPF Cage Migration E2E", () => {
       PROCESS_TIME,
       RETRACT_TIME,
     )
-      .mint({ maxFee: 500_000n })
-      .request(INSERT_KEY, INSERT_VALUE, { fee: 500_000n })
+      .mint({ tip: 500_000n })
+      .request(INSERT_KEY, INSERT_VALUE, { tip: 500_000n })
       .modify(MODIFIED_ROOT)
       .end();
   });

--- a/spec/CageDatum.lean
+++ b/spec/CageDatum.lean
@@ -61,7 +61,7 @@ inductive Operation where
 structure State where
   owner       : VKH
   root        : Hash       -- current MPF root (Blake2b-256)
-  maxFee      : Nat        -- max lovelace fee per request
+  tip         : Nat        -- oracle tip per request (lovelace)
   processTime : Nat        -- Phase 1 duration (ms)
   retractTime : Nat        -- Phase 2 duration (ms)
 
@@ -71,7 +71,7 @@ structure Request where
   requestOwner : VKH
   requestKey   : Bytes
   requestValue : Operation
-  fee          : Nat
+  tip          : Nat        -- requester agrees to oracle's tip
   submittedAt  : POSIXTime
 
 /-- Datum discriminator for UTxOs at the script address. -/
@@ -118,6 +118,7 @@ structure TxOutput where
 structure Transaction where
   inputs          : List TxInput
   outputs         : List TxOutput
+  fee             : Nat              -- actual transaction fee (Plutus V3)
   mint            : PolicyId → TokenId → Int   -- (policy, token) → quantity
   extraSignatories : List VKH
   validityRange   : Interval
@@ -354,26 +355,35 @@ structure ValidReject (state : State)
   /-- Each request is rejectable. -/
   rejectable : ∀ (pair : TxInput × Request), pair ∈ requests →
                isRejectable tx.validityRange pair.2.submittedAt state
-  /-- Each request fee matches state max_fee. -/
-  feeMatch  : ∀ (pair : TxInput × Request), pair ∈ requests →
-              pair.2.fee = state.maxFee
-  /-- Refunds: each requester receives inputLovelace - fee. -/
-  refunds   : ∀ (pair : TxInput × Request), pair ∈ requests →
-              ∃ o ∈ tx.outputs,
-                o.address = sorry ∧  -- requestOwner's address
-                o.value ≥ pair.1.value - pair.2.fee
+  /-- Each request tip matches state tip. -/
+  tipMatch  : ∀ (pair : TxInput × Request), pair ∈ requests →
+              pair.2.tip = state.tip
+  /-- Conservation: total refunded = total input - tx.fee - N * tip. -/
+  conservation :
+    ∀ refundOutputs : List TxOutput,
+      (refundOutputs.map (·.value)).sum
+        = (requests.map (·.1.value)).sum - tx.fee - requests.length * state.tip
 
 -- ============================================================================
 -- 15. Fee enforcement
 -- ============================================================================
 
-/-- During Modify, each request's fee must equal the state's max_fee,
-    and the requester is refunded inputLovelace - fee. -/
-structure FeeEnforced (state : State) (reqInput : TxInput)
-    (request : Request) (tx : Transaction) : Prop where
-  feeMatch : request.fee = state.maxFee
-  refund   : ∃ o ∈ tx.outputs,
-             o.value ≥ reqInput.value - request.fee
+/-- During Modify, the oracle collects exactly the tx fee plus tips.
+    Each request's tip must match the state's declared tip. The total
+    refunded equals total input lovelace minus tx fee minus N × tip. -/
+structure FeeEnforced (state : State)
+    (requests : List (TxInput × Request))
+    (refundOutputs : List TxOutput)
+    (tx : Transaction) : Prop where
+  /-- Each request's tip matches the state's declared tip. -/
+  tipMatch : ∀ (pair : TxInput × Request), pair ∈ requests →
+             pair.2.tip = state.tip
+  /-- One refund output per request (with lovelace > 0). -/
+  refundCount : refundOutputs.length = requests.length
+  /-- Conservation: sum of refunds = sum of inputs - tx.fee - N * tip. -/
+  conservation :
+    (refundOutputs.map (·.value)).sum
+      = (requests.map (·.1.value)).sum - tx.fee - requests.length * state.tip
 
 -- ============================================================================
 -- 16. Migration

--- a/validators/cage.ak
+++ b/validators/cage.ak
@@ -576,18 +576,20 @@ pub fn is_rejectable(
 /// - Request with Insert on existing key -> mpf.insert fails
 /// - Request with Delete on non-existent key -> mpf.delete fails
 /// - Request with Update with wrong old value -> mpf.update fails
-fn mkUpdate(tokenId, max_fee, process_time, validity_range) {
+fn mkUpdate(tokenId, state_tip, process_time, validity_range) {
   fn(
     input: Input,
     acc: (
       MerklePatriciaForestry,
       List<Proof>,
       List<Pair<VerificationKeyHash, Int>>,
+      Int,
     ),
   ) -> (
     MerklePatriciaForestry,
     List<Proof>,
     List<Pair<VerificationKeyHash, Int>>,
+    Int,
   ) {
     when input.output.datum is {
       InlineDatum(datum) ->
@@ -597,15 +599,15 @@ fn mkUpdate(tokenId, max_fee, process_time, validity_range) {
             requestKey,
             requestValue,
             requestOwner,
-            fee,
+            tip,
             submitted_at,
           } = request
           if requestToken == tokenId {
-            // Fee must match the state's max_fee
-            expect fee == max_fee
+            // Tip must match the state's declared tip
+            expect tip == state_tip
             // Request must be in Phase 1
             expect in_phase1(validity_range, submitted_at, process_time)
-            let (root, proofs, refunds) = acc
+            let (root, proofs, owners, totalInputLovelace) = acc
             let proof, proofsTail <- uncons(proofs)
             let newRoot =
               when requestValue is {
@@ -614,16 +616,14 @@ fn mkUpdate(tokenId, max_fee, process_time, validity_range) {
                 Update(oldValue, newValue) ->
                   mpf.update(root, requestKey, proof, oldValue, newValue)
               }
-            // Compute refund: input lovelace minus fee
             let inputLovelace = assets.lovelace_of(input.output.value)
-            let refundAmount = inputLovelace - fee
-            let newRefunds =
-              if refundAmount > 0 {
-                [Pair(requestOwner, refundAmount), ..refunds]
+            let newOwners =
+              if inputLovelace > 0 {
+                [Pair(requestOwner, inputLovelace), ..owners]
               } else {
-                refunds
+                owners
               }
-            (newRoot, proofsTail, newRefunds)
+            (newRoot, proofsTail, newOwners, totalInputLovelace + inputLovelace)
           } else {
             acc
           }
@@ -635,23 +635,21 @@ fn mkUpdate(tokenId, max_fee, process_time, validity_range) {
   }
 }
 
-/// Verify that refund outputs match the expected refunds.
+/// Sum refund output lovelaces, verifying each goes to the correct owner.
 ///
-/// Walks the output list in parallel with the refunds list.
-/// For each refund, checks that the output pays at least
-/// the refund amount to the correct owner address.
-fn verifyRefunds(
+/// Walks the output list in parallel with the owners list.
+/// Returns the total lovelace across all refund outputs.
+fn sumRefunds(
   outputs: List<Output>,
-  refunds: List<Pair<VerificationKeyHash, Int>>,
-) -> Bool {
-  when refunds is {
-    [] -> True
-    [Pair(owner, amount), ..rest] -> {
+  owners: List<Pair<VerificationKeyHash, Int>>,
+) -> Int {
+  when owners is {
+    [] -> 0
+    [Pair(owner, _inputLovelace), ..rest] -> {
       expect [output, ..remaining] = outputs
       expect address.VerificationKey(vkh) = output.address.payment_credential
       expect vkh == owner
-      expect assets.lovelace_of(output.value) >= amount
-      verifyRefunds(remaining, rest)
+      assets.lovelace_of(output.value) + sumRefunds(remaining, rest)
     }
   }
 }
@@ -725,8 +723,8 @@ fn validRootUpdate(
   tx: Transaction,
   proofs: List<Proof>,
 ) {
-  let Transaction { outputs, inputs, validity_range, .. } = tx
-  let State { root, max_fee, process_time, retract_time, .. } = state
+  let Transaction { outputs, inputs, validity_range, fee: tx_fee, .. } = tx
+  let State { root, tip, process_time, retract_time, .. } = state
   expect Some(output) = head(outputs)
   expect InlineDatum(outState) = output.datum
   expect
@@ -742,45 +740,51 @@ fn validRootUpdate(
   expect process_time == outProcessTime
   expect retract_time == outRetractTime
 
-  let (expectedNewRoot, _, refunds) =
+  let (expectedNewRoot, _, owners, totalInputLovelace) =
     inputs
       |> foldl(
-          (mpf.from_root(root), proofs, []),
-          mkUpdate(tokenId, max_fee, process_time, validity_range),
+          (mpf.from_root(root), proofs, [], 0),
+          mkUpdate(tokenId, tip, process_time, validity_range),
         )
   expect (mpf.root(expectedNewRoot) == newRoot)?
   expect
     output.address.payment_credential == input.output.address.payment_credential
 
   // Verify refund outputs (starting after the State UTxO at index 0)
+  let n = list.length(owners)
   expect [_, ..refundOutputs] = outputs
-  let orderedRefunds = list.reverse(refunds)
-  expect verifyRefunds(refundOutputs, orderedRefunds)
+  let orderedOwners = list.reverse(owners)
+  let totalRefunded = sumRefunds(refundOutputs, orderedOwners)
+  // Conservation: total refunded == total input lovelace - tx fee - N * tip
+  expect totalRefunded == totalInputLovelace - tx_fee - n * tip
   True
 }
 
-/// Create a reject function for folding over inputs to collect refunds.
+/// Create a reject function for folding over inputs to collect owners/lovelaces.
 /// Like mkUpdate but: no proofs, no MPF operations, is_rejectable check.
 fn mkReject(
   tokenId,
-  max_fee,
+  state_tip,
   process_time,
   retract_time,
   validity_range,
 ) {
-  fn(input: Input, refunds: List<Pair<VerificationKeyHash, Int>>) {
+  fn(
+    input: Input,
+    acc: (List<Pair<VerificationKeyHash, Int>>, Int),
+  ) -> (List<Pair<VerificationKeyHash, Int>>, Int) {
     when input.output.datum is {
       InlineDatum(datum) ->
         if datum is RequestDatum(request): CageDatum {
           let Request {
             requestToken,
             requestOwner,
-            fee,
+            tip,
             submitted_at,
             ..
           } = request
           if requestToken == tokenId {
-            expect fee == max_fee
+            expect tip == state_tip
             expect
               is_rejectable(
                 validity_range,
@@ -788,34 +792,36 @@ fn mkReject(
                 process_time,
                 retract_time,
               )
+            let (owners, totalInputLovelace) = acc
             let inputLovelace = assets.lovelace_of(input.output.value)
-            let refundAmount = inputLovelace - fee
-            if refundAmount > 0 {
-              [Pair(requestOwner, refundAmount), ..refunds]
-            } else {
-              refunds
-            }
+            let newOwners =
+              if inputLovelace > 0 {
+                [Pair(requestOwner, inputLovelace), ..owners]
+              } else {
+                owners
+              }
+            (newOwners, totalInputLovelace + inputLovelace)
           } else {
-            refunds
+            acc
           }
         } else {
-          refunds
+          acc
         }
-      _ -> refunds
+      _ -> acc
     }
   }
 }
 
 /// Validate a Reject operation: discard expired/dishonest requests.
-/// Root MUST NOT change. Refunds enforced for each rejected request.
+/// Root MUST NOT change. Conservation equation enforced.
 fn validReject(
   state: State,
   input: Input,
   tokenId: TokenId,
   tx: Transaction,
 ) {
-  let Transaction { outputs, inputs, validity_range, .. } = tx
-  let State { root, max_fee, process_time, retract_time, .. } = state
+  let Transaction { outputs, inputs, validity_range, fee: tx_fee, .. } = tx
+  let State { root, tip, process_time, retract_time, .. } = state
 
   expect Some(output) = head(outputs)
   expect InlineDatum(outState) = output.datum
@@ -836,22 +842,25 @@ fn validReject(
   expect
     output.address.payment_credential == input.output.address.payment_credential
 
-  let refunds =
+  let (owners, totalInputLovelace) =
     inputs
       |> foldl(
-          [],
+          ([], 0),
           mkReject(
             tokenId,
-            max_fee,
+            tip,
             process_time,
             retract_time,
             validity_range,
           ),
         )
 
+  let n = list.length(owners)
   expect [_, ..refundOutputs] = outputs
-  let orderedRefunds = list.reverse(refunds)
-  expect verifyRefunds(refundOutputs, orderedRefunds)
+  let orderedOwners = list.reverse(owners)
+  let totalRefunded = sumRefunds(refundOutputs, orderedOwners)
+  // Conservation: total refunded == total input lovelace - tx fee - N * tip
+  expect totalRefunded == totalInputLovelace - tx_fee - n * tip
   True
 }
 

--- a/validators/cage.tests.ak
+++ b/validators/cage.tests.ak
@@ -79,7 +79,7 @@ const state =
   State {
     owner: "owner",
     root: root(mpf.empty),
-    max_fee: 0,
+    tip: 0,
     process_time: testProcessTime,
     retract_time: testRetractTime,
   }
@@ -98,7 +98,7 @@ const aRequest =
       requestKey: "42",
       requestValue: Insert("42"),
       requestOwner: "owner",
-      fee: 0,
+      tip: 0,
       submitted_at: 0,
     },
   )
@@ -137,7 +137,7 @@ const output =
         State {
           owner: "new-owner",
           root: #"484dee386bcb51e285896271048baf6ea4396b2ee95be6fd29a92a0eeb8462ea",
-          max_fee: 0,
+          tip: 0,
           process_time: testProcessTime,
           retract_time: testRetractTime,
         },
@@ -203,7 +203,7 @@ const minted =
         State {
           owner: "owner",
           root: root(empty),
-          max_fee: 0,
+          tip: 0,
           process_time: testProcessTime,
           retract_time: testRetractTime,
         },
@@ -299,7 +299,7 @@ test mint_to_wrong_script() fail {
 /// A non-empty root would mean data exists without ever being inserted.
 test mint_nonempty_root() fail {
   let bad_output =
-    Output { ..minted, datum: InlineDatum(StateDatum(State { owner: "owner", root: "nonempty_root", max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })) }
+    Output { ..minted, datum: InlineDatum(StateDatum(State { owner: "owner", root: "nonempty_root", tip: 0, process_time: testProcessTime, retract_time: testRetractTime })) }
   cage.mpfCage.mint(
     0,
     Minting(minting), "policy_id",
@@ -315,7 +315,7 @@ test mint_request_datum() fail {
       ..minted,
       datum: InlineDatum(RequestDatum(Request {
         requestToken: token, requestKey: "k", requestValue: Insert("v"),
-        requestOwner: "owner", fee: 0, submitted_at: 0,
+        requestOwner: "owner", tip: 0, submitted_at: 0,
       })),
     }
   cage.mpfCage.mint(
@@ -379,7 +379,7 @@ test retract_in_phase3() fail {
 test contribute_wrong_token() fail {
   let wrong_request = RequestDatum(Request {
     requestToken: TokenId { assetName: "different_asset" },
-    requestKey: "42", requestValue: Insert("42"), requestOwner: "owner", fee: 0, submitted_at: 0,
+    requestKey: "42", requestValue: Insert("42"), requestOwner: "owner", tip: 0, submitted_at: 0,
   })
   cage.mpfCage.spend(0, Some(wrong_request), Contribute(testStateRef), testRequestRef,
     Transaction { ..transaction.placeholder, validity_range: phase1Range, inputs: [update, request] })
@@ -440,7 +440,7 @@ test modify_owner_transfer() {
 test modify_no_requests() {
   let unchanged_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   cage.mpfCage.spend(0, stateDatum, Modify([]), testStateRef,
@@ -453,7 +453,7 @@ test modify_no_requests() {
 test modify_skip_other_token() {
   let other_request_datum = RequestDatum(Request {
     requestToken: TokenId { assetName: "other_token" },
-    requestKey: "42", requestValue: Insert("42"), requestOwner: "someone", fee: 0, submitted_at: 0,
+    requestKey: "42", requestValue: Insert("42"), requestOwner: "someone", tip: 0, submitted_at: 0,
   })
   let other_request = Input {
     output_reference: OutputReference { transaction_id: "3334567890abcdef", output_index: 1 },
@@ -461,7 +461,7 @@ test modify_skip_other_token() {
   }
   let unchanged_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   cage.mpfCage.spend(0, stateDatum, Modify([]), testStateRef,
@@ -487,7 +487,7 @@ test modify_extra_proofs() {
 test modify_wrong_root() fail {
   let bad_root_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "new-owner", root: "wrong_root_hash", max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "new-owner", root: "wrong_root_hash", tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   cage.mpfCage.spend(0, stateDatum, Modify([[]]), testStateRef,
@@ -602,7 +602,7 @@ fn owner_fuzzer() -> Fuzzer<ByteArray> {
 test prop_retract_requires_owner(signer via owner_fuzzer()) fail once {
   let req = RequestDatum(Request {
     requestToken: testToken, requestKey: "k", requestValue: Insert("v"),
-    requestOwner: "the_real_owner_key_aaaaaaaaaa", fee: 0, submitted_at: 0,
+    requestOwner: "the_real_owner_key_aaaaaaaaaa", tip: 0, submitted_at: 0,
   })
   cage.mpfCage.spend(0, Some(req), Retract(testStateRef), testRequestRef,
     Transaction { ..transaction.placeholder, validity_range: phase2Range, extra_signatories: [signer], reference_inputs: [update] })
@@ -615,10 +615,10 @@ test prop_retract_requires_owner(signer via owner_fuzzer()) fail once {
 /// doesn't match the state owner. This verifies `has(extra_signatories, owner)`
 /// protects the MPF state from unauthorized modifications.
 test prop_modify_requires_owner(signer via owner_fuzzer()) fail once {
-  let s = State { owner: "the_real_owner_key_aaaaaaaaaa", root: root(empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime }
+  let s = State { owner: "the_real_owner_key_aaaaaaaaaa", root: root(empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime }
   let unchanged_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "the_real_owner_key_aaaaaaaaaa", root: root(empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "the_real_owner_key_aaaaaaaaaa", root: root(empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   let state_input = Input {
@@ -647,7 +647,7 @@ test prop_mint_roundtrip(params via fuzz.tuple(fuzz.bytearray_fixed(32), fuzz.in
   let addr = address.from_script("policy_id")
   let out = Output {
     address: addr, value: val,
-    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   let utxo = Output { address: paying_address, value: zero, datum: NoDatum, reference_script: None }
@@ -679,7 +679,7 @@ const migrate_output =
   Output {
     address: address.from_script(new_policy),
     value: from_asset(new_policy, migrate_token.assetName, 1),
-    datum: InlineDatum(StateDatum(State { owner: "owner", root: "nonempty_root_hash_aaaaaaaaa", max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "owner", root: "nonempty_root_hash_aaaaaaaaa", tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
 
@@ -723,15 +723,15 @@ test migrate_wrong_old_policy() fail {
 // outputs are present, sufficient, and sent to the correct address.
 // ============================================================================
 
-const testFee = 500_000
+const testTip = 500_000
 
-const feeState = State { owner: "owner", root: root(mpf.empty), max_fee: testFee, process_time: testProcessTime, retract_time: testRetractTime }
+const feeState = State { owner: "owner", root: root(mpf.empty), tip: testTip, process_time: testProcessTime, retract_time: testRetractTime }
 
 const feeStateDatum = Some(StateDatum(feeState))
 
 const feeRequest = RequestDatum(Request {
   requestToken: testToken, requestKey: "42", requestValue: Insert("42"),
-  requestOwner: "requester_key_aaaaaaaaaaaaaaa", fee: testFee, submitted_at: 0,
+  requestOwner: "requester_key_aaaaaaaaaaaaaaa", tip: testTip, submitted_at: 0,
 })
 
 const feeRequestInput = Input {
@@ -747,7 +747,7 @@ const feeStateInput = Input {
 const feeStateOutput = Output {
   address: testScriptAddress, value: testValue,
   datum: InlineDatum(StateDatum(State {
-    owner: "new-owner", root: #"484dee386bcb51e285896271048baf6ea4396b2ee95be6fd29a92a0eeb8462ea", max_fee: testFee,
+    owner: "new-owner", root: #"484dee386bcb51e285896271048baf6ea4396b2ee95be6fd29a92a0eeb8462ea", tip: testTip,
     process_time: testProcessTime, retract_time: testRetractTime,
   })),
   reference_script: None,
@@ -791,10 +791,10 @@ test modify_wrong_refund_address() fail {
 /// When fee is 0, the full input ADA is refunded. No ADA is retained by the
 /// cage owner. This is the "free service" case.
 test modify_zero_fee() {
-  let zf_state = State { owner: "owner", root: root(mpf.empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime }
+  let zf_state = State { owner: "owner", root: root(mpf.empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime }
   let zf_request = RequestDatum(Request {
     requestToken: testToken, requestKey: "42", requestValue: Insert("42"),
-    requestOwner: "requester_key_aaaaaaaaaaaaaaa", fee: 0, submitted_at: 0,
+    requestOwner: "requester_key_aaaaaaaaaaaaaaa", tip: 0, submitted_at: 0,
   })
   let zf_request_input = Input {
     output_reference: testRequestRef,
@@ -806,7 +806,7 @@ test modify_zero_fee() {
   }
   let zf_state_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "new-owner", root: #"484dee386bcb51e285896271048baf6ea4396b2ee95be6fd29a92a0eeb8462ea", max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "new-owner", root: #"484dee386bcb51e285896271048baf6ea4396b2ee95be6fd29a92a0eeb8462ea", tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   let zf_refund = Output {
@@ -817,12 +817,12 @@ test modify_zero_fee() {
     Transaction { ..transaction.placeholder, validity_range: phase1Range, outputs: [zf_state_output, zf_refund], extra_signatories: ["owner"], inputs: [zf_state_input, zf_request_input] })
 }
 
-/// The request's fee must match the state's max_fee. A mismatch means the
+/// The request's fee must match the state's tip. A mismatch means the
 /// request was created for a different fee tier and must be rejected.
 test modify_fee_mismatch() fail {
   let mismatch_request = RequestDatum(Request {
     requestToken: testToken, requestKey: "42", requestValue: Insert("42"),
-    requestOwner: "requester_key_aaaaaaaaaaaaaaa", fee: 100_000, submitted_at: 0,
+    requestOwner: "requester_key_aaaaaaaaaaaaaaa", tip: 100_000, submitted_at: 0,
   })
   let mismatch_input = Input {
     output_reference: testRequestRef,
@@ -830,6 +830,60 @@ test modify_fee_mismatch() fail {
   }
   cage.mpfCage.spend(0, feeStateDatum, Modify([[]]), testStateRef,
     Transaction { ..transaction.placeholder, validity_range: phase1Range, outputs: [feeStateOutput, refundOutput], extra_signatories: ["owner"], inputs: [feeStateInput, mismatch_input] })
+}
+
+/// Modify with nonzero tx fee: conservation equation deducts the tx fee.
+/// Request has 2 ADA, tip is 0.5 ADA, tx fee is 200_000.
+/// Expected refund: 2_000_000 - 200_000 - 500_000 = 1_300_000.
+test modify_with_tx_fee() {
+  let tx_fee_refund = Output {
+    address: address.from_verification_key("requester_key_aaaaaaaaaaaaaaa"),
+    value: from_lovelace(1_300_000), datum: NoDatum, reference_script: None,
+  }
+  cage.mpfCage.spend(0, feeStateDatum, Modify([[]]), testStateRef,
+    Transaction { ..transaction.placeholder, fee: 200_000, validity_range: phase1Range, outputs: [feeStateOutput, tx_fee_refund], extra_signatories: ["owner"], inputs: [feeStateInput, feeRequestInput] })
+}
+
+/// Modify with nonzero tx fee: wrong refund amount fails conservation.
+test modify_with_tx_fee_wrong_refund() fail {
+  cage.mpfCage.spend(0, feeStateDatum, Modify([[]]), testStateRef,
+    Transaction { ..transaction.placeholder, fee: 200_000, validity_range: phase1Range, outputs: [feeStateOutput, refundOutput], extra_signatories: ["owner"], inputs: [feeStateInput, feeRequestInput] })
+}
+
+/// Batch Modify with two requests: conservation splits tx fee across both.
+/// Two requests each with 2 ADA, tip 0.5 ADA, tx fee 300_000.
+/// Total refund: 4_000_000 - 300_000 - 2 * 500_000 = 2_700_000.
+test modify_batch_two_requests() {
+  // Second request: same key "42" but Delete (undo the first Insert)
+  let request2_datum = RequestDatum(Request {
+    requestToken: testToken, requestKey: "42", requestValue: Delete("42"),
+    requestOwner: "second_requester_key_aaaaaaaaaa", tip: testTip, submitted_at: 0,
+  })
+  let request2_ref = OutputReference { transaction_id: "3334567890abcdef", output_index: 253 }
+  let request2_input = Input {
+    output_reference: request2_ref,
+    output: Output { address: testScriptAddress, value: from_lovelace(2_000_000), datum: InlineDatum(request2_datum), reference_script: None },
+  }
+  // Insert("42","42") then Delete("42","42") → back to empty root
+  let batch_state_output = Output {
+    address: testScriptAddress, value: testValue,
+    datum: InlineDatum(StateDatum(State {
+      owner: "new-owner", root: root(mpf.empty), tip: testTip,
+      process_time: testProcessTime, retract_time: testRetractTime,
+    })),
+    reference_script: None,
+  }
+  // Refunds: 1_350_000 each = (4_000_000 - 300_000 - 1_000_000) / 2
+  let refund1 = Output {
+    address: address.from_verification_key("requester_key_aaaaaaaaaaaaaaa"),
+    value: from_lovelace(1_350_000), datum: NoDatum, reference_script: None,
+  }
+  let refund2 = Output {
+    address: address.from_verification_key("second_requester_key_aaaaaaaaaa"),
+    value: from_lovelace(1_350_000), datum: NoDatum, reference_script: None,
+  }
+  cage.mpfCage.spend(0, feeStateDatum, Modify([[], []]), testStateRef,
+    Transaction { ..transaction.placeholder, fee: 300_000, validity_range: phase1Range, outputs: [batch_state_output, refund1, refund2], extra_signatories: ["owner"], inputs: [feeStateInput, feeRequestInput, request2_input] })
 }
 
 /// End succeeds even when the mint field contains additional policies beyond
@@ -852,7 +906,7 @@ test end_with_extra_mint_policy() {
 
 const rejectStateOutput = Output {
   address: testScriptAddress, value: testValue,
-  datum: InlineDatum(StateDatum(State { owner: "owner", root: root(mpf.empty), max_fee: testFee, process_time: testProcessTime, retract_time: testRetractTime })),
+  datum: InlineDatum(StateDatum(State { owner: "owner", root: root(mpf.empty), tip: testTip, process_time: testProcessTime, retract_time: testRetractTime })),
   reference_script: None,
 }
 
@@ -883,7 +937,7 @@ test reject_in_phase2() fail {
 test reject_future_submitted_at() {
   let future_request = RequestDatum(Request {
     requestToken: testToken, requestKey: "42", requestValue: Insert("42"),
-    requestOwner: "requester_key_aaaaaaaaaaaaaaa", fee: testFee, submitted_at: 100_000,
+    requestOwner: "requester_key_aaaaaaaaaaaaaaa", tip: testTip, submitted_at: 100_000,
   })
   let future_request_input = Input {
     output_reference: testRequestRef,
@@ -906,17 +960,29 @@ test reject_missing_signature() fail {
 test reject_root_changes() fail {
   let bad_reject_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "owner", root: "different_root_aaaaaaaaaaaaa", max_fee: testFee, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "owner", root: "different_root_aaaaaaaaaaaaa", tip: testTip, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   cage.mpfCage.spend(0, feeStateDatum, Reject, testStateRef,
     Transaction { ..transaction.placeholder, validity_range: phase3Range, outputs: [bad_reject_output, refundOutput], extra_signatories: ["owner"], inputs: [feeStateInput, feeRequestInput] })
 }
 
-/// Even rejected requests must have their ADA refunded (minus fee).
-/// Providing an insufficient refund shortchanges the requester.
+/// Even rejected requests must have their ADA refunded correctly.
+/// Providing an insufficient refund fails the conservation check.
 test reject_wrong_refund() fail {
   let bad_refund = Output { ..refundOutput, value: from_lovelace(500_000) }
   cage.mpfCage.spend(0, feeStateDatum, Reject, testStateRef,
     Transaction { ..transaction.placeholder, validity_range: phase3Range, outputs: [rejectStateOutput, bad_refund], extra_signatories: ["owner"], inputs: [feeStateInput, feeRequestInput] })
+}
+
+/// Reject with nonzero tx fee: conservation equation deducts the tx fee.
+/// Request has 2 ADA, tip is 0.5 ADA, tx fee is 200_000.
+/// Expected refund: 2_000_000 - 200_000 - 500_000 = 1_300_000.
+test reject_with_tx_fee() {
+  let tx_fee_refund = Output {
+    address: address.from_verification_key("requester_key_aaaaaaaaaaaaaaa"),
+    value: from_lovelace(1_300_000), datum: NoDatum, reference_script: None,
+  }
+  cage.mpfCage.spend(0, feeStateDatum, Reject, testStateRef,
+    Transaction { ..transaction.placeholder, fee: 200_000, validity_range: phase3Range, outputs: [rejectStateOutput, tx_fee_refund], extra_signatories: ["owner"], inputs: [feeStateInput, feeRequestInput] })
 }

--- a/validators/types.ak
+++ b/validators/types.ak
@@ -231,9 +231,10 @@ pub type State {
   /// The current Merkle Patricia Forestry root hash.
   /// This commits to all key-value pairs stored in the MPF.
   root: ByteArray,
-  /// The maximum fee (in lovelace) the oracle charges per request.
-  /// Requesters must agree to this fee by recording it in their Request datum.
-  max_fee: Int,
+  /// The oracle's tip per request (in lovelace).
+  /// Requesters agree to this tip by recording it in their Request datum.
+  /// The actual tx fee is split across requests at Modify time (Plutus V3).
+  tip: Int,
   /// Duration (in milliseconds) of Phase 1 — the oracle processing window.
   /// Set at mint time; enforced immutable across Modify/Reject operations.
   process_time: Int,
@@ -335,9 +336,9 @@ pub type Request {
   /// The operation to perform on the key.
   /// See `Operation` type for details on Insert, Delete, and Update.
   requestValue: Operation,
-  /// The fee (in lovelace) the requester agrees to pay.
-  /// Must match `state.max_fee` at Modify time.
-  fee: Int,
+  /// The oracle tip (in lovelace) the requester agrees to pay.
+  /// Must match `state.tip` at Modify time.
+  tip: Int,
   /// The POSIXTime (in milliseconds) when the request was submitted.
   /// Used for time-gated phase enforcement: Phase 1 (oracle-only),
   /// Phase 2 (requester retract), Phase 3 (oracle reject/cleanup).


### PR DESCRIPTION
## Summary

- Replace fixed `max_fee` with fair fee model: requesters pay share of actual tx fee + oracle tip
- `State.max_fee` → `State.tip`, `Request.fee` → `Request.tip`
- Conservation equation: `sum(refunds) == sum(inputs) - tx.fee - N * tip`
- Uses Plutus V3 `Transaction.fee` for actual tx cost

## Changes

- **spec/CageDatum.lean**: Updated formal spec with conservation equation
- **validators/types.ak**: Field renames in State and Request
- **validators/cage.ak**: `mkUpdate`, `mkReject`, `validRootUpdate`, `validReject` rewritten
- **validators/cage.tests.ak**: All tests updated + 4 new tests (91 total, all passing)

Closes #35