### PR TITLE
fix: replace fixed max_fee with fair fee model (tx.fee + tip)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,45 +49,6 @@ jobs:
       - name: Build Lean proofs
         run: nix shell nixpkgs#lean4 -c lake build
 
-  typecheck:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: e2e
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: e2e/package-lock.json
-
-      - run: npm ci
-
-      - run: npx tsc --noEmit
-
-  e2e:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Download plutus.json
-        uses: actions/download-artifact@v6
-        with:
-          name: plutus-json
-
-      - name: Prepare plutus.json
-        run: |
-          # The artifact is the blueprint file itself (named "result" from nix symlink)
-          # Rename to plutus.json for the docker-compose mount
-          if [ -f result ]; then mv result plutus.json; fi
-          ls -la plutus.json
-
-      - name: Run E2E tests
-        run: docker compose -f e2e/docker-compose.yml up --build --abort-on-container-exit test-runner
-
-      - name: Cleanup
-        if: always()
-        run: docker compose -f e2e/docker-compose.yml down -v
+  # TypeScript E2E removed — replaced by Haskell E2E
+  # in cardano-mpfs-offchain (CageFlow tests).
+  # See https://github.com/cardano-foundation/cardano-mpfs-onchain/issues/42

--- a/cardano-mpfs-onchain/cardano-mpfs-onchain.cabal
+++ b/cardano-mpfs-onchain/cardano-mpfs-onchain.cabal
@@ -1,0 +1,88 @@
+cabal-version:   3.4
+name:            cardano-mpfs-onchain
+version:         0.1.0.0
+synopsis:        Canonical on-chain types for MPFS cage validator
+license:         Apache-2.0
+author:          Paolo Veronelli
+maintainer:      paolo.veronelli@gmail.com
+category:        Cardano
+build-type:      Simple
+
+common warnings
+  ghc-options:
+    -Wall -Werror -Wunused-imports -Wunused-packages
+    -Wmissing-export-lists -Wname-shadowing -Wredundant-constraints
+
+  default-extensions:
+    DataKinds
+    DerivingStrategies
+    DuplicateRecordFields
+    FlexibleContexts
+    GADTs
+    ImportQualifiedPost
+    OverloadedStrings
+    PatternSynonyms
+    RecordWildCards
+    ScopedTypeVariables
+    StrictData
+    TypeApplications
+    TypeOperators
+    ViewPatterns
+
+library
+  import:           warnings
+  hs-source-dirs:   lib
+  default-language: GHC2021
+  exposed-modules:
+    Cardano.MPFS.OnChain
+    Cardano.MPFS.OnChain.AssetName
+    Cardano.MPFS.OnChain.Datum
+    Cardano.MPFS.OnChain.Script
+    Cardano.MPFS.OnChain.Types
+
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cryptonite
+    , memory
+    , microlens
+    , plutus-core
+    , plutus-ledger-api
+    , plutus-tx
+    , text
+
+test-suite e2e-tests
+  import:           warnings
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   e2e-test
+  main-is:          Main.hs
+  default-language: GHC2021
+  other-modules:
+    CageE2ESpec
+    CageTxBuilder
+
+  build-depends:
+    , base
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-allegra
+    , cardano-ledger-alonzo
+    , cardano-ledger-api
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , cardano-ledger-mary
+    , cardano-mpfs-onchain
+    , cardano-node-clients
+    , cardano-node-clients:devnet
+    , cardano-strict-containers
+    , containers
+    , hspec
+    , microlens
+    , plutus-tx

--- a/cardano-mpfs-onchain/e2e-test/CageE2ESpec.hs
+++ b/cardano-mpfs-onchain/e2e-test/CageE2ESpec.hs
@@ -1,0 +1,216 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module CageE2ESpec (spec) where
+
+import Control.Concurrent (threadDelay)
+import Data.ByteString qualified as BS
+import Data.Maybe (listToMaybe)
+import System.Environment (lookupEnv)
+import Test.Hspec
+
+import Data.Set qualified as Set
+import Lens.Micro ((&), (.~))
+
+import Cardano.Ledger.Address (Addr)
+import Cardano.Ledger.Api.Tx (mkBasicTx)
+import Cardano.Ledger.Api.Tx.Body (collateralInputsTxBodyL, mkBasicTxBody)
+
+import Cardano.Node.Client.Balance (balanceTx)
+import Cardano.Node.Client.E2E.Setup
+    ( addKeyWitness
+    , genesisAddr
+    , genesisSignKey
+    , keyHashFromSignKey
+    , withDevnet
+    )
+import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.Submitter (Submitter (..), SubmitResult (..))
+
+import Cardano.MPFS.OnChain.AssetName (computeAssetName)
+import Cardano.MPFS.OnChain.Types
+    ( OnChainTokenId (..)
+    )
+import PlutusTx.Builtins.Internal (BuiltinByteString (..))
+
+import CageTxBuilder
+
+requireJust :: String -> Maybe a -> IO a
+requireJust msg Nothing = fail msg
+requireJust _ (Just x) = pure x
+
+spec :: Spec
+spec = do
+    around setupDevnet $ do
+        describe "MPF Cage E2E" $ do
+            it "self-transfer with collateral" selfTransferWithCollateral
+            it "mint and end" mintAndEnd
+            it "modify with tip" modifyWithTip
+            it "reject after retract window" rejectAfterRetract
+
+type DevnetEnv = (CageEnv, Addr)
+
+setupDevnet :: (DevnetEnv -> IO ()) -> IO ()
+setupDevnet action = do
+    bpPath <- lookupEnv "MPFS_BLUEPRINT"
+    let bp = maybe "plutus.json" id bpPath
+    withDevnet $ \lsq ltxs -> do
+        env <- mkCageEnv bp 0 lsq ltxs
+        action (env, genesisAddr)
+
+selfTransferWithCollateral :: DevnetEnv -> IO ()
+selfTransferWithCollateral (env, addr) = do
+    let sk = genesisSignKey
+    pp <- queryProtocolParams (envProvider env)
+    utxos <- queryUTxOs (envProvider env) addr
+    utxos `shouldSatisfy` (not . null)
+    seedUtxo <- requireJust "seed UTxO" $ listToMaybe utxos
+    let body = mkBasicTxBody
+            & collateralInputsTxBodyL .~ Set.singleton (fst seedUtxo)
+        tx = mkBasicTx body
+    case balanceTx pp utxos addr tx of
+        Left err -> fail $ "Balance error: " <> show err
+        Right balanced -> do
+            let signed = addKeyWitness sk balanced
+            result <- submitTx (envSubmitter env) signed
+            case result of
+                Submitted _ -> pure ()
+                Rejected reason -> fail $ "Rejected: " <> show reason
+
+mintAndEnd :: DevnetEnv -> IO ()
+mintAndEnd (env, addr) = do
+    let sk = genesisSignKey
+        kh = keyHashFromSignKey sk
+    utxos <- queryUTxOs (envProvider env) addr
+    utxos `shouldSatisfy` (not . null)
+    seedUtxo <- requireJust "seed UTxO" $ listToMaybe utxos
+    -- Mint
+    mintTx <- buildMintTx env kh addr seedUtxo 0 60_000 60_000
+    signAndSubmit env sk mintTx
+    waitForTx
+    -- Verify state UTxO exists
+    scriptUtxos <- queryScriptUtxos env
+    stateUtxo <- requireJust "state UTxO" $ findStateUtxo env scriptUtxos
+    -- End
+    endTx <- buildEndTx env kh addr stateUtxo
+    signAndSubmit env sk endTx
+    waitForTx
+    -- Verify token is gone
+    scriptUtxos' <- queryScriptUtxos env
+    let mState' = findStateUtxo env scriptUtxos'
+    mState' `shouldBe` Nothing
+
+modifyWithTip :: DevnetEnv -> IO ()
+modifyWithTip (env, addr) = do
+    let sk = genesisSignKey
+        kh = keyHashFromSignKey sk
+        tip = 500_000
+    utxos <- queryUTxOs (envProvider env) addr
+    seedUtxo <- requireJust "seed UTxO" $ listToMaybe utxos
+    let assetName = computeAssetName (fst seedUtxo)
+        tokenId = OnChainTokenId (BuiltinByteString assetName)
+    mintTx <- buildMintTx env kh addr seedUtxo tip 600_000 600_000
+    signAndSubmit env sk mintTx
+    waitForTx
+    -- Request
+    let submittedAt = envStartMs env + 5_000
+    reqTx <-
+        buildRequestTx
+            env
+            kh
+            addr
+            assetName
+            tokenId
+            "42"
+            "42"
+            tip
+            submittedAt
+    signAndSubmit env sk reqTx
+    waitForTx
+    -- Find state and request UTxOs
+    scriptUtxos <- queryScriptUtxos env
+    stateUtxo <- requireJust "state UTxO" $ findStateUtxo env scriptUtxos
+    let reqUtxos =
+            filter
+                (\(tin, _) -> tin /= fst stateUtxo)
+                scriptUtxos
+    reqUtxos `shouldSatisfy` (not . null)
+    -- Modify
+    modTx <-
+        buildModifyTx
+            env
+            kh
+            addr
+            stateUtxo
+            reqUtxos
+            BS.empty
+            tip
+            600_000
+            600_000
+    signAndSubmit env sk modTx
+    waitForTx
+    -- End
+    scriptUtxos' <- queryScriptUtxos env
+    stateUtxo' <- requireJust "state UTxO" $ findStateUtxo env scriptUtxos'
+    endTx <- buildEndTx env kh addr stateUtxo'
+    signAndSubmit env sk endTx
+    waitForTx
+
+rejectAfterRetract :: DevnetEnv -> IO ()
+rejectAfterRetract (env, addr) = do
+    let sk = genesisSignKey
+        kh = keyHashFromSignKey sk
+        processTime = 10_000
+        retractTime = 10_000
+    utxos <- queryUTxOs (envProvider env) addr
+    seedUtxo <- requireJust "seed UTxO" $ listToMaybe utxos
+    let assetName = computeAssetName (fst seedUtxo)
+        tokenId = OnChainTokenId (BuiltinByteString assetName)
+    mintTx <- buildMintTx env kh addr seedUtxo 0 processTime retractTime
+    signAndSubmit env sk mintTx
+    waitForTx
+    -- Request
+    let submittedAt = envStartMs env + 5_000
+    reqTx <-
+        buildRequestTx
+            env
+            kh
+            addr
+            assetName
+            tokenId
+            "42"
+            "42"
+            0
+            submittedAt
+    signAndSubmit env sk reqTx
+    waitForTx
+    -- Wait for phase 3
+    let waitMs = processTime + retractTime + 2_000
+    threadDelay (fromIntegral waitMs * 1000)
+    -- Find state and request UTxOs
+    scriptUtxos <- queryScriptUtxos env
+    stateUtxo <- requireJust "state UTxO" $ findStateUtxo env scriptUtxos
+    let reqUtxos =
+            filter
+                (\(tin, _) -> tin /= fst stateUtxo)
+                scriptUtxos
+    reqUtxos `shouldSatisfy` (not . null)
+    -- Reject
+    rejTx <-
+        buildRejectTx
+            env
+            kh
+            addr
+            stateUtxo
+            reqUtxos
+            0
+            processTime
+            retractTime
+    signAndSubmit env sk rejTx
+    waitForTx
+    -- End
+    scriptUtxos' <- queryScriptUtxos env
+    stateUtxo' <- requireJust "state UTxO" $ findStateUtxo env scriptUtxos'
+    endTx <- buildEndTx env kh addr stateUtxo'
+    signAndSubmit env sk endTx
+    waitForTx

--- a/cardano-mpfs-onchain/e2e-test/CageTxBuilder.hs
+++ b/cardano-mpfs-onchain/e2e-test/CageTxBuilder.hs
@@ -1,0 +1,964 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module CageTxBuilder
+    ( -- * Script setup
+      CageEnv (..)
+    , mkCageEnv
+
+      -- * Transaction builders
+    , buildMintTx
+    , buildRequestTx
+    , buildModifyTx
+    , buildRejectTx
+    , buildEndTx
+
+      -- * Helpers
+    , signAndSubmit
+    , waitForTx
+    , queryScriptUtxos
+    , findStateUtxo
+    ) where
+
+import Control.Concurrent (threadDelay)
+import Data.ByteString qualified as BS
+import Data.ByteString.Short qualified as SBS
+import Data.Map.Strict qualified as Map
+import Data.Sequence.Strict qualified as StrictSeq
+import Data.Set qualified as Set
+import Data.Word (Word32)
+import Lens.Micro ((&), (.~), (^.))
+
+import Cardano.Crypto.Hash (hashToBytes)
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Allegra.Scripts
+    ( ValidityInterval (..)
+    )
+import Cardano.Ledger.Alonzo.PParams
+    ( LangDepView
+    , getLanguageView
+    )
+import Cardano.Ledger.Alonzo.Scripts (AsIx (..))
+import Cardano.Ledger.Alonzo.Tx
+    ( ScriptIntegrityHash
+    , hashScriptIntegrity
+    )
+import Cardano.Ledger.Alonzo.TxBody
+    ( reqSignerHashesTxBodyL
+    , scriptIntegrityHashTxBodyL
+    )
+import Cardano.Ledger.Alonzo.TxWits
+    ( Redeemers (..)
+    , TxDats (..)
+    )
+import Cardano.Ledger.Api.Tx
+    ( Tx
+    , bodyTxL
+    , mkBasicTx
+    , witsTxL
+    )
+import Cardano.Ledger.Api.Tx.Body
+    ( collateralInputsTxBodyL
+    , feeTxBodyL
+    , inputsTxBodyL
+    , mintTxBodyL
+    , mkBasicTxBody
+    , outputsTxBodyL
+    , vldtTxBodyL
+    )
+import Cardano.Ledger.Api.Tx.Out
+    ( TxOut
+    , coinTxOutL
+    , datumTxOutL
+    , mkBasicTxOut
+    , valueTxOutL
+    )
+import Cardano.Ledger.Api.Tx.Wits
+    ( rdmrsTxWitsL
+    , scriptTxWitsL
+    )
+import Cardano.Ledger.BaseTypes
+    ( Inject (..)
+    , Network (..)
+    , SlotNo (..)
+    , StrictMaybe (SJust)
+    , TxIx (..)
+    )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Scripts
+    ( ConwayPlutusPurpose (..)
+    )
+import Cardano.Ledger.Core
+    ( PParams
+    , Script
+    , extractHash
+    , hashScript
+    )
+import Cardano.Ledger.Credential
+    ( Credential (..)
+    , StakeReference (..)
+    )
+import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Ledger.Keys
+    ( KeyHash (..)
+    , KeyRole (..)
+    , coerceKeyRole
+    )
+import Cardano.Ledger.Mary.Value
+    ( MaryValue (..)
+    , MultiAsset (..)
+    , PolicyID (..)
+    )
+import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
+import Cardano.Ledger.Plutus.Language
+    ( Language (PlutusV3)
+    )
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Ledger.Mary.Value qualified as Value
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    )
+
+
+import Cardano.MPFS.OnChain.AssetName (computeAssetName)
+import Cardano.MPFS.OnChain.Datum
+    ( mkInlineDatum
+    , toLedgerData
+    , toPlcData
+    )
+import Cardano.MPFS.OnChain.Script
+    ( applyVersion
+    , extractCompiledCode
+    , loadBlueprint
+    , mkCageScript
+    )
+import Cardano.MPFS.OnChain.Types
+
+import Cardano.Node.Client.Balance (balanceTx)
+import Cardano.Node.Client.E2E.Setup
+    ( addKeyWitness
+    )
+import Cardano.Node.Client.N2C.Provider (mkN2CProvider)
+import Cardano.Node.Client.N2C.Submitter (mkN2CSubmitter)
+import Cardano.Node.Client.N2C.Types
+    ( LSQChannel
+    , LTxSChannel
+    )
+import Cardano.Node.Client.Provider (Provider (..))
+import Cardano.Node.Client.Submitter
+    ( SubmitResult (..)
+    , Submitter (..)
+    )
+import Cardano.Crypto.DSIGN (Ed25519DSIGN, SignKeyDSIGN)
+
+data CageEnv = CageEnv
+    { envScript :: Script ConwayEra
+    , envScriptHash :: ScriptHash
+    , envPolicyId :: PolicyID
+    , envScriptAddr :: Addr
+    , envMintScriptBytes :: SBS.ShortByteString
+    , envSpendScriptBytes :: SBS.ShortByteString
+    , envMintScript :: Script ConwayEra
+    , envSpendScript :: Script ConwayEra
+    , envMintScriptHash :: ScriptHash
+    , envSpendScriptHash :: ScriptHash
+    , envProvider :: Provider IO
+    , envSubmitter :: Submitter IO
+    , envStartMs :: Integer
+    }
+
+mkCageEnv
+    :: FilePath
+    -> Integer
+    -> LSQChannel
+    -> LTxSChannel
+    -> IO CageEnv
+mkCageEnv bpPath startMs lsq ltxs = do
+    bp <- loadBlueprint bpPath >>= either fail pure
+    let cageCode =
+            maybe
+                (error "cage compiled code not found")
+                id
+                (extractCompiledCode "cage." bp)
+        appliedCode = applyVersion 0 cageCode
+        cageScr = mkCageScript appliedCode
+        cageHash = hashScript @ConwayEra cageScr
+        policyId = PolicyID cageHash
+        scriptAddr =
+            Addr
+                Testnet
+                (ScriptHashObj cageHash)
+                StakeRefNull
+        provider = mkN2CProvider lsq
+        submitter = mkN2CSubmitter ltxs
+    pure
+        CageEnv
+            { envScript = cageScr
+            , envScriptHash = cageHash
+            , envPolicyId = policyId
+            , envScriptAddr = scriptAddr
+            , envMintScriptBytes = appliedCode
+            , envSpendScriptBytes = appliedCode
+            , envMintScript = cageScr
+            , envSpendScript = cageScr
+            , envMintScriptHash = cageHash
+            , envSpendScriptHash = cageHash
+            , envProvider = provider
+            , envSubmitter = submitter
+            , envStartMs = startMs
+            }
+
+placeholderExUnits :: ExUnits
+placeholderExUnits = ExUnits 0 0
+
+emptyRoot :: BS.ByteString
+emptyRoot = BS.replicate 32 0
+
+computeScriptIntegrity
+    :: PParams ConwayEra
+    -> Redeemers ConwayEra
+    -> StrictMaybe ScriptIntegrityHash
+computeScriptIntegrity pp rdmrs =
+    let langViews :: Set.Set LangDepView
+        langViews =
+            Set.singleton
+                (getLanguageView pp PlutusV3)
+        emptyDats = TxDats mempty
+    in  hashScriptIntegrity langViews rdmrs emptyDats
+
+spendingIndex :: TxIn -> Set.Set TxIn -> Word32
+spendingIndex needle inputs =
+    let sorted = Set.toAscList inputs
+    in  go 0 sorted
+  where
+    go _ [] =
+        error "spendingIndex: TxIn not in set"
+    go n (x : xs)
+        | x == needle = n
+        | otherwise = go (n + 1) xs
+
+evaluateAndBalance
+    :: Provider IO
+    -> PParams ConwayEra
+    -> [(TxIn, TxOut ConwayEra)]
+    -> Addr
+    -> Tx ConwayEra
+    -> IO (Tx ConwayEra)
+evaluateAndBalance prov pp inputUtxos changeAddr tx =
+    do
+        let existingIns =
+                tx ^. bodyTxL . inputsTxBodyL
+            allIns =
+                foldl
+                    ( \s (tin, _) ->
+                        Set.insert tin s
+                    )
+                    existingIns
+                    inputUtxos
+            txForEval =
+                tx
+                    & bodyTxL . inputsTxBodyL
+                        .~ allIns
+        evalResult <- evaluateTx prov txForEval
+        let Redeemers rdmrMap =
+                tx ^. witsTxL . rdmrsTxWitsL
+            patched =
+                Map.mapWithKey
+                    ( \purpose (dat, eu) ->
+                        case Map.lookup
+                            purpose
+                            evalResult of
+                            Just (Right eu') ->
+                                (dat, eu')
+                            _ -> (dat, eu)
+                    )
+                    rdmrMap
+            newRedeemers = Redeemers patched
+            integrity =
+                computeScriptIntegrity
+                    pp
+                    newRedeemers
+            -- Rebuild the body with new integrity to avoid
+            -- composed lens losing collateral from MemoBytes
+            oldBody = tx ^. bodyTxL
+            newBody = oldBody
+                & scriptIntegrityHashTxBodyL .~ integrity
+            patched' =
+                tx
+                    & witsTxL . rdmrsTxWitsL
+                        .~ newRedeemers
+                    & bodyTxL .~ newBody
+        case balanceTx
+            pp
+            inputUtxos
+            changeAddr
+            patched' of
+            Left err ->
+                error
+                    $ "evaluateAndBalance: "
+                        <> show err
+            Right balanced -> pure balanced
+
+-- | Build a mint transaction.
+buildMintTx
+    :: CageEnv
+    -> KeyHash 'Payment
+    -> Addr
+    -> (TxIn, TxOut ConwayEra)
+    -> Integer
+    -> Integer
+    -> Integer
+    -> IO (Tx ConwayEra)
+buildMintTx env _ownerKh ownerAddr seedUtxo tip processTime retractTime = do
+    pp <- queryProtocolParams (envProvider env)
+    walletUtxos <- queryUTxOs (envProvider env) ownerAddr
+    let (seedIn, _) = seedUtxo
+        otherUtxos =
+            filter (\(tin, _) -> tin /= seedIn) walletUtxos
+        feeUtxo = case otherUtxos of
+            (u : _) -> Just u
+            [] -> Nothing
+        collateralIn = maybe seedIn fst feeUtxo
+        extraUtxos = case feeUtxo of
+            Just fu -> [fu, seedUtxo]
+            Nothing -> [seedUtxo]
+        assetName = computeAssetName seedIn
+        assetNameSbs = SBS.toShort assetName
+        assetNameLedger = Value.AssetName assetNameSbs
+        ownerKhBytes = case ownerAddr of
+            Addr _ (KeyHashObj kh) _ ->
+                let KeyHash h = kh
+                in  hashToBytes h
+            _ -> error "buildMintTx: not a key address"
+        stateDatum =
+            StateDatum
+                OnChainTokenState
+                    { stateOwner =
+                        BuiltinByteString
+                            ownerKhBytes
+                    , stateRoot = OnChainRoot emptyRoot
+                    , stateTip = tip
+                    , stateProcessTime = processTime
+                    , stateRetractTime = retractTime
+                    }
+        cageDatum = toPlcData stateDatum
+        txOutRef = txInToRef seedIn
+        mintRedeemer =
+            Minting (Mint txOutRef)
+        mint =
+            MultiAsset
+                $ Map.singleton
+                    (envPolicyId env)
+                    (Map.singleton assetNameLedger 1)
+        stateOutput =
+            mkBasicTxOut
+                (envScriptAddr env)
+                ( MaryValue
+                    (Coin 2_000_000)
+                    mint
+                )
+                & datumTxOutL
+                    .~ mkInlineDatum cageDatum
+        allScriptIns = Set.singleton seedIn
+        mintRdmr =
+            Redeemers
+                $ Map.singleton
+                    (ConwayMinting (AsIx 0))
+                    ( toLedgerData mintRedeemer
+                    , placeholderExUnits
+                    )
+        integrity =
+            computeScriptIntegrity pp mintRdmr
+        body =
+            mkBasicTxBody
+                & inputsTxBodyL .~ allScriptIns
+                & outputsTxBodyL
+                    .~ StrictSeq.singleton stateOutput
+                & mintTxBodyL .~ mint
+                & collateralInputsTxBodyL
+                    .~ Set.singleton collateralIn
+                & scriptIntegrityHashTxBodyL
+                    .~ integrity
+        tx =
+            mkBasicTx body
+                & witsTxL . scriptTxWitsL
+                    .~ Map.singleton
+                        (envMintScriptHash env)
+                        (envMintScript env)
+                & witsTxL . rdmrsTxWitsL
+                    .~ mintRdmr
+    evaluateAndBalance
+        (envProvider env)
+        pp
+        extraUtxos
+        ownerAddr
+        tx
+
+-- | Build a request transaction (simple payment, no scripts).
+buildRequestTx
+    :: CageEnv
+    -> KeyHash 'Payment
+    -> Addr
+    -> BS.ByteString
+    -> OnChainTokenId
+    -> BS.ByteString
+    -> BS.ByteString
+    -> Integer
+    -> Integer
+    -> IO (Tx ConwayEra)
+buildRequestTx env _ownerKh ownerAddr _assetNameBs tokenId key value tip submittedAt = do
+    pp <- queryProtocolParams (envProvider env)
+    let ownerKhBytes = case ownerAddr of
+            Addr _ (KeyHashObj kh) _ ->
+                let KeyHash h = kh
+                in  hashToBytes h
+            _ -> error "buildRequestTx: not a key address"
+        reqDatum =
+            RequestDatum
+                OnChainRequest
+                    { requestToken = tokenId
+                    , requestOwner =
+                        BuiltinByteString
+                            ownerKhBytes
+                    , requestKey = key
+                    , requestValue = OpInsert value
+                    , requestTip = tip
+                    , requestSubmittedAt = submittedAt
+                    }
+        reqOutput =
+            mkBasicTxOut
+                (envScriptAddr env)
+                (inject (Coin 2_000_000))
+                & datumTxOutL
+                    .~ mkInlineDatum (toPlcData reqDatum)
+        body =
+            mkBasicTxBody
+                & outputsTxBodyL
+                    .~ StrictSeq.singleton reqOutput
+        tx = mkBasicTx body
+    walletUtxos <- queryUTxOs (envProvider env) ownerAddr
+    let feeUtxo = case walletUtxos of
+            [] -> error "buildRequestTx: no wallet UTxOs"
+            (u : _) -> u
+    case balanceTx pp [feeUtxo] ownerAddr tx of
+        Left err ->
+            error $ "buildRequestTx: " <> show err
+        Right balanced -> pure balanced
+
+-- | Build a modify transaction with conservation-aware fee handling.
+buildModifyTx
+    :: CageEnv
+    -> KeyHash 'Payment
+    -> Addr
+    -> (TxIn, TxOut ConwayEra)
+    -> [(TxIn, TxOut ConwayEra)]
+    -> BS.ByteString
+    -> Integer
+    -> Integer
+    -> Integer
+    -> IO (Tx ConwayEra)
+buildModifyTx env ownerKh ownerAddr stateUtxo reqUtxos _newRoot tip processTime retractTime = do
+    pp <- queryProtocolParams (envProvider env)
+    let (stateIn, stateOut) = stateUtxo
+        reqIns = map fst reqUtxos
+        overestimate = Coin 500_000
+        numReqs = fromIntegral (length reqUtxos)
+        totalInputLovelace =
+            foldl
+                ( \(Coin acc) (_, o) ->
+                    let Coin c = o ^. coinTxOutL
+                    in  Coin (acc + c)
+                )
+                (Coin 0)
+                reqUtxos
+        Coin totalIn = totalInputLovelace
+        Coin overEst = overestimate
+        totalRefund = totalIn - overEst - numReqs * tip
+        perRequest =
+            if numReqs > 0
+                then totalRefund `div` numReqs
+                else 0
+        remainder =
+            if numReqs > 0
+                then totalRefund `mod` numReqs
+                else 0
+        ownerKhBytes = case ownerAddr of
+            Addr _ (KeyHashObj kh) _ ->
+                let KeyHash h = kh
+                in  hashToBytes h
+            _ -> error "buildModifyTx: not a key address"
+        assetNameSbs = case stateOut ^. valueTxOutL of
+            MaryValue _ (MultiAsset ma) ->
+                case Map.lookup (envPolicyId env) ma of
+                    Just assets ->
+                        case Map.keys assets of
+                            (Value.AssetName an : _) -> an
+                            _ -> error "buildModifyTx: no asset"
+                    Nothing -> error "buildModifyTx: no policy"
+        assetNameLedger = Value.AssetName assetNameSbs
+        newStateDatum =
+            StateDatum
+                OnChainTokenState
+                    { stateOwner =
+                        BuiltinByteString
+                            ownerKhBytes
+                    , stateRoot = OnChainRoot emptyRoot
+                    , stateTip = tip
+                    , stateProcessTime = processTime
+                    , stateRetractTime = retractTime
+                    }
+        mint =
+            MultiAsset
+                $ Map.singleton
+                    (envPolicyId env)
+                    (Map.singleton assetNameLedger 1)
+        newStateOut =
+            mkBasicTxOut
+                (envScriptAddr env)
+                (MaryValue (Coin 2_000_000) mint)
+                & datumTxOutL
+                    .~ mkInlineDatum
+                        (toPlcData newStateDatum)
+        mkRefundOut i =
+            mkBasicTxOut
+                ownerAddr
+                ( inject
+                    ( Coin
+                        ( perRequest
+                            + if i == (0 :: Int)
+                                then remainder
+                                else 0
+                        )
+                    )
+                )
+        refundOuts =
+            map mkRefundOut [0 .. length reqUtxos - 1]
+        allOuts =
+            StrictSeq.fromList
+                (newStateOut : refundOuts)
+        allScriptIns =
+            Set.fromList (stateIn : reqIns)
+        -- Compute proofs: empty for E2E (empty MPF)
+        proofs = map (const []) reqUtxos
+        stateRef = txInToRef stateIn
+        modifyRedeemer = Modify proofs
+        stateIx =
+            spendingIndex stateIn allScriptIns
+        contributeEntries =
+            map
+                ( \rIn ->
+                    let ix =
+                            spendingIndex
+                                rIn
+                                allScriptIns
+                        rdm = Contribute stateRef
+                    in  ( ConwaySpending (AsIx ix)
+                        ,
+                            ( toLedgerData rdm
+                            , placeholderExUnits
+                            )
+                        )
+                )
+                reqIns
+        redeemers =
+            Redeemers
+                $ Map.fromList
+                $ ( ConwaySpending
+                        (AsIx stateIx)
+                  ,
+                      ( toLedgerData modifyRedeemer
+                      , placeholderExUnits
+                      )
+                  )
+                    : contributeEntries
+        integrity =
+            computeScriptIntegrity pp redeemers
+        witnessKh =
+            coerceKeyRole ownerKh
+                :: KeyHash 'Witness
+        -- Validity: current time window
+        nowMs = envStartMs env + 10_000
+        nowSlot = SlotNo (fromIntegral (nowMs `div` 1000))
+        upperSlot = SlotNo (fromIntegral ((nowMs + 60_000) `div` 1000))
+        vldt =
+            ValidityInterval
+                (SJust nowSlot)
+                (SJust upperSlot)
+        body =
+            mkBasicTxBody
+                & inputsTxBodyL .~ allScriptIns
+                & outputsTxBodyL .~ allOuts
+                & feeTxBodyL .~ overestimate
+                & reqSignerHashesTxBodyL
+                    .~ Set.singleton witnessKh
+                & vldtTxBodyL .~ vldt
+                & scriptIntegrityHashTxBodyL
+                    .~ integrity
+        tx =
+            mkBasicTx body
+                & witsTxL . scriptTxWitsL
+                    .~ Map.singleton
+                        (envSpendScriptHash env)
+                        (envSpendScript env)
+                & witsTxL . rdmrsTxWitsL
+                    .~ redeemers
+    -- Conservation-aware: evaluate but don't rebalance
+    -- (fee is already set, change goes to oracle via refunds)
+    walletUtxos <- queryUTxOs (envProvider env) ownerAddr
+    let feeUtxo = case walletUtxos of
+            [] -> error "buildModifyTx: no wallet UTxOs"
+            (u : _) -> u
+        _allInputUtxos = feeUtxo : stateUtxo : reqUtxos
+    -- Add collateral
+    let txWithCollateral =
+            tx
+                & bodyTxL . collateralInputsTxBodyL
+                    .~ Set.singleton (fst feeUtxo)
+                & bodyTxL . inputsTxBodyL
+                    .~ Set.insert (fst feeUtxo) allScriptIns
+    evalResult <- evaluateTx (envProvider env) txWithCollateral
+    let Redeemers rdmrMap =
+            txWithCollateral ^. witsTxL . rdmrsTxWitsL
+        patchedRdmrs =
+            Map.mapWithKey
+                ( \purpose (dat, eu) ->
+                    case Map.lookup
+                        purpose
+                        evalResult of
+                        Just (Right eu') ->
+                            (dat, eu')
+                        _ -> (dat, eu)
+                )
+                rdmrMap
+        newRedeemers = Redeemers patchedRdmrs
+        newIntegrity =
+            computeScriptIntegrity pp newRedeemers
+    pure
+        $ txWithCollateral
+            & witsTxL . rdmrsTxWitsL
+                .~ newRedeemers
+            & bodyTxL
+                . scriptIntegrityHashTxBodyL
+                .~ newIntegrity
+
+-- | Build a reject transaction with conservation-aware fee handling.
+buildRejectTx
+    :: CageEnv
+    -> KeyHash 'Payment
+    -> Addr
+    -> (TxIn, TxOut ConwayEra)
+    -> [(TxIn, TxOut ConwayEra)]
+    -> Integer
+    -> Integer
+    -> Integer
+    -> IO (Tx ConwayEra)
+buildRejectTx env ownerKh ownerAddr stateUtxo reqUtxos tip processTime retractTime = do
+    pp <- queryProtocolParams (envProvider env)
+    let (stateIn, stateOut) = stateUtxo
+        reqIns = map fst reqUtxos
+        overestimate = Coin 500_000
+        numReqs = fromIntegral (length reqUtxos)
+        totalInputLovelace =
+            foldl
+                ( \(Coin acc) (_, o) ->
+                    let Coin c = o ^. coinTxOutL
+                    in  Coin (acc + c)
+                )
+                (Coin 0)
+                reqUtxos
+        Coin totalIn = totalInputLovelace
+        Coin overEst = overestimate
+        totalRefund = totalIn - overEst - numReqs * tip
+        perRequest =
+            if numReqs > 0
+                then totalRefund `div` numReqs
+                else 0
+        remainder =
+            if numReqs > 0
+                then totalRefund `mod` numReqs
+                else 0
+        ownerKhBytes = case ownerAddr of
+            Addr _ (KeyHashObj kh) _ ->
+                let KeyHash h = kh
+                in  hashToBytes h
+            _ -> error "buildRejectTx: not a key address"
+        assetNameSbs = case stateOut ^. valueTxOutL of
+            MaryValue _ (MultiAsset ma) ->
+                case Map.lookup (envPolicyId env) ma of
+                    Just assets ->
+                        case Map.keys assets of
+                            (Value.AssetName an : _) -> an
+                            _ -> error "buildRejectTx: no asset"
+                    Nothing -> error "buildRejectTx: no policy"
+        assetNameLedger = Value.AssetName assetNameSbs
+        -- Same datum (root unchanged for reject)
+        sameDatum =
+            StateDatum
+                OnChainTokenState
+                    { stateOwner =
+                        BuiltinByteString
+                            ownerKhBytes
+                    , stateRoot = OnChainRoot emptyRoot
+                    , stateTip = tip
+                    , stateProcessTime = processTime
+                    , stateRetractTime = retractTime
+                    }
+        mint =
+            MultiAsset
+                $ Map.singleton
+                    (envPolicyId env)
+                    (Map.singleton assetNameLedger 1)
+        newStateOut =
+            mkBasicTxOut
+                (envScriptAddr env)
+                (MaryValue (Coin 2_000_000) mint)
+                & datumTxOutL
+                    .~ mkInlineDatum (toPlcData sameDatum)
+        mkRefundOut i =
+            mkBasicTxOut
+                ownerAddr
+                ( inject
+                    ( Coin
+                        ( perRequest
+                            + if i == (0 :: Int)
+                                then remainder
+                                else 0
+                        )
+                    )
+                )
+        refundOuts =
+            map mkRefundOut [0 .. length reqUtxos - 1]
+        allOuts =
+            StrictSeq.fromList
+                (newStateOut : refundOuts)
+        allScriptIns =
+            Set.fromList (stateIn : reqIns)
+        stateRef = txInToRef stateIn
+        rejectRedeemer = Reject
+        stateIx =
+            spendingIndex stateIn allScriptIns
+        contributeEntries =
+            map
+                ( \rIn ->
+                    let ix =
+                            spendingIndex
+                                rIn
+                                allScriptIns
+                        rdm = Contribute stateRef
+                    in  ( ConwaySpending (AsIx ix)
+                        ,
+                            ( toLedgerData rdm
+                            , placeholderExUnits
+                            )
+                        )
+                )
+                reqIns
+        redeemers =
+            Redeemers
+                $ Map.fromList
+                $ ( ConwaySpending
+                        (AsIx stateIx)
+                  ,
+                      ( toLedgerData rejectRedeemer
+                      , placeholderExUnits
+                      )
+                  )
+                    : contributeEntries
+        integrity =
+            computeScriptIntegrity pp redeemers
+        witnessKh =
+            coerceKeyRole ownerKh
+                :: KeyHash 'Witness
+        -- Validity: must be after process_time + retract_time
+        -- Use slots well past phase 3
+        nowMs = envStartMs env + processTime + retractTime + 5_000
+        nowSlot = SlotNo (fromIntegral (nowMs `div` 1000))
+        upperSlot = SlotNo (fromIntegral ((nowMs + 60_000) `div` 1000))
+        vldt =
+            ValidityInterval
+                (SJust nowSlot)
+                (SJust upperSlot)
+        body =
+            mkBasicTxBody
+                & inputsTxBodyL .~ allScriptIns
+                & outputsTxBodyL .~ allOuts
+                & feeTxBodyL .~ overestimate
+                & reqSignerHashesTxBodyL
+                    .~ Set.singleton witnessKh
+                & vldtTxBodyL .~ vldt
+                & scriptIntegrityHashTxBodyL
+                    .~ integrity
+        tx =
+            mkBasicTx body
+                & witsTxL . scriptTxWitsL
+                    .~ Map.singleton
+                        (envSpendScriptHash env)
+                        (envSpendScript env)
+                & witsTxL . rdmrsTxWitsL
+                    .~ redeemers
+    walletUtxos <- queryUTxOs (envProvider env) ownerAddr
+    let feeUtxo = case walletUtxos of
+            [] -> error "buildRejectTx: no wallet UTxOs"
+            (u : _) -> u
+        _allInputUtxos = feeUtxo : stateUtxo : reqUtxos
+    let txWithCollateral =
+            tx
+                & bodyTxL . collateralInputsTxBodyL
+                    .~ Set.singleton (fst feeUtxo)
+                & bodyTxL . inputsTxBodyL
+                    .~ Set.insert (fst feeUtxo) allScriptIns
+    evalResult <- evaluateTx (envProvider env) txWithCollateral
+    let Redeemers rdmrMap =
+            txWithCollateral ^. witsTxL . rdmrsTxWitsL
+        patchedRdmrs =
+            Map.mapWithKey
+                ( \purpose (dat, eu) ->
+                    case Map.lookup
+                        purpose
+                        evalResult of
+                        Just (Right eu') ->
+                            (dat, eu')
+                        _ -> (dat, eu)
+                )
+                rdmrMap
+        newRedeemers = Redeemers patchedRdmrs
+        newIntegrity =
+            computeScriptIntegrity pp newRedeemers
+    pure
+        $ txWithCollateral
+            & witsTxL . rdmrsTxWitsL
+                .~ newRedeemers
+            & bodyTxL
+                . scriptIntegrityHashTxBodyL
+                .~ newIntegrity
+
+-- | Build an end transaction (burn token, spend state UTxO).
+buildEndTx
+    :: CageEnv
+    -> KeyHash 'Payment
+    -> Addr
+    -> (TxIn, TxOut ConwayEra)
+    -> IO (Tx ConwayEra)
+buildEndTx env ownerKh ownerAddr stateUtxo = do
+    pp <- queryProtocolParams (envProvider env)
+    let (stateIn, stateOut) = stateUtxo
+        assetNameSbs = case stateOut ^. valueTxOutL of
+            MaryValue _ (MultiAsset ma) ->
+                case Map.lookup (envPolicyId env) ma of
+                    Just assets ->
+                        case Map.keys assets of
+                            (Value.AssetName an : _) -> an
+                            _ -> error "buildEndTx: no asset"
+                    Nothing -> error "buildEndTx: no policy"
+        assetNameLedger = Value.AssetName assetNameSbs
+        burn =
+            MultiAsset
+                $ Map.singleton
+                    (envPolicyId env)
+                    (Map.singleton assetNameLedger (-1))
+        endRedeemer = End
+        burnRedeemer = Burning
+        allScriptIns = Set.singleton stateIn
+        stateIx = spendingIndex stateIn allScriptIns
+        redeemers =
+            Redeemers
+                $ Map.fromList
+                    [ ( ConwaySpending (AsIx stateIx)
+                      ,
+                          ( toLedgerData endRedeemer
+                          , placeholderExUnits
+                          )
+                      )
+                    , ( ConwayMinting (AsIx 0)
+                      ,
+                          ( toLedgerData burnRedeemer
+                          , placeholderExUnits
+                          )
+                      )
+                    ]
+        integrity =
+            computeScriptIntegrity pp redeemers
+        witnessKh =
+            coerceKeyRole ownerKh
+                :: KeyHash 'Witness
+        body =
+            mkBasicTxBody
+                & inputsTxBodyL .~ allScriptIns
+                & mintTxBodyL .~ burn
+                & reqSignerHashesTxBodyL
+                    .~ Set.singleton witnessKh
+                & scriptIntegrityHashTxBodyL
+                    .~ integrity
+        tx =
+            mkBasicTx body
+                & witsTxL . scriptTxWitsL
+                    .~ Map.fromList
+                        [ (envMintScriptHash env, envMintScript env)
+                        , (envSpendScriptHash env, envSpendScript env)
+                        ]
+                & witsTxL . rdmrsTxWitsL
+                    .~ redeemers
+    walletUtxos <- queryUTxOs (envProvider env) ownerAddr
+    let feeUtxo = case walletUtxos of
+            [] -> error "buildEndTx: no wallet UTxOs"
+            (u : _) -> u
+    evaluateAndBalance
+        (envProvider env)
+        pp
+        [feeUtxo, stateUtxo]
+        ownerAddr
+        tx
+
+-- | Helper: convert TxIn to OnChainTxOutRef
+txInToRef :: TxIn -> OnChainTxOutRef
+txInToRef (TxIn (TxId h) (TxIx ix)) =
+    OnChainTxOutRef
+        { txOutRefId =
+            BuiltinByteString
+                (hashToBytes (extractHash h))
+        , txOutRefIdx = fromIntegral ix
+        }
+
+-- | Sign a transaction and submit it.
+signAndSubmit
+    :: CageEnv
+    -> SignKeyDSIGN Ed25519DSIGN
+    -> Tx ConwayEra
+    -> IO ()
+signAndSubmit env sk tx = do
+    let signed = addKeyWitness sk tx
+    result <- submitTx (envSubmitter env) signed
+    case result of
+        Submitted _ -> pure ()
+        Rejected reason ->
+            error
+                $ "Transaction rejected: "
+                    <> show reason
+
+-- | Wait for a transaction to be confirmed.
+waitForTx :: IO ()
+waitForTx = threadDelay 5_000_000
+
+-- | Query UTxOs at the cage script address.
+queryScriptUtxos
+    :: CageEnv -> IO [(TxIn, TxOut ConwayEra)]
+queryScriptUtxos env =
+    queryUTxOs (envProvider env) (envScriptAddr env)
+
+-- | Find the state UTxO (the one holding the cage token).
+findStateUtxo
+    :: CageEnv
+    -> [(TxIn, TxOut ConwayEra)]
+    -> Maybe (TxIn, TxOut ConwayEra)
+findStateUtxo env = go
+  where
+    go [] = Nothing
+    go ((tin, tout) : rest) =
+        case tout ^. valueTxOutL of
+            MaryValue _ (MultiAsset ma) ->
+                case Map.lookup (envPolicyId env) ma of
+                    Just assets
+                        | not (Map.null assets) ->
+                            Just (tin, tout)
+                    _ -> go rest

--- a/cardano-mpfs-onchain/e2e-test/Main.hs
+++ b/cardano-mpfs-onchain/e2e-test/Main.hs
@@ -1,0 +1,8 @@
+module Main (main) where
+
+import Test.Hspec (hspec)
+
+import CageE2ESpec qualified
+
+main :: IO ()
+main = hspec CageE2ESpec.spec

--- a/cardano-mpfs-onchain/lib/Cardano/MPFS/OnChain.hs
+++ b/cardano-mpfs-onchain/lib/Cardano/MPFS/OnChain.hs
@@ -1,0 +1,18 @@
+module Cardano.MPFS.OnChain
+    ( -- * Types
+      module Cardano.MPFS.OnChain.Types
+
+      -- * Script
+    , module Cardano.MPFS.OnChain.Script
+
+      -- * AssetName
+    , module Cardano.MPFS.OnChain.AssetName
+
+      -- * Datum
+    , module Cardano.MPFS.OnChain.Datum
+    ) where
+
+import Cardano.MPFS.OnChain.AssetName
+import Cardano.MPFS.OnChain.Datum
+import Cardano.MPFS.OnChain.Script
+import Cardano.MPFS.OnChain.Types

--- a/cardano-mpfs-onchain/lib/Cardano/MPFS/OnChain/AssetName.hs
+++ b/cardano-mpfs-onchain/lib/Cardano/MPFS/OnChain/AssetName.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.MPFS.OnChain.AssetName
+    ( computeAssetName
+    ) where
+
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Ledger.BaseTypes (TxIx (..))
+import Cardano.Ledger.Core (extractHash)
+import Cardano.Crypto.Hash (hashToBytes)
+import Crypto.Hash (Digest, SHA256, hash)
+import Data.Bits (shiftR)
+import Data.ByteArray (convert)
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Word (Word16)
+
+computeAssetName :: TxIn -> ByteString
+computeAssetName (TxIn (TxId h) (TxIx ix)) =
+    convert digest
+  where
+    digest :: Digest SHA256
+    digest = hash (txIdBytes <> indexBytes)
+
+    txIdBytes :: ByteString
+    txIdBytes = hashToBytes (extractHash h)
+
+    indexBytes :: ByteString
+    indexBytes =
+        let w16 = fromIntegral ix :: Word16
+        in  BS.pack
+                [ fromIntegral (w16 `shiftR` 8)
+                , fromIntegral w16
+                ]

--- a/cardano-mpfs-onchain/lib/Cardano/MPFS/OnChain/Datum.hs
+++ b/cardano-mpfs-onchain/lib/Cardano/MPFS/OnChain/Datum.hs
@@ -1,0 +1,53 @@
+module Cardano.MPFS.OnChain.Datum
+    ( mkInlineDatum
+    , extractCageDatum
+    , toPlcData
+    , toLedgerData
+    ) where
+
+import Cardano.Ledger.Api.Scripts.Data
+    ( Data (..)
+    , Datum (..)
+    , binaryDataToData
+    , dataToBinaryData
+    )
+import Cardano.Ledger.Api.Tx.Out
+    ( TxOut
+    , datumTxOutL
+    )
+import Cardano.Ledger.Conway (ConwayEra)
+import Lens.Micro ((^.))
+import PlutusCore.Data qualified as PLC
+import PlutusTx.Builtins.Internal
+    ( BuiltinData (..)
+    )
+import PlutusTx.IsData.Class
+    ( FromData (..)
+    , ToData (..)
+    )
+
+import Cardano.MPFS.OnChain.Types (CageDatum)
+
+toPlcData :: (ToData a) => a -> PLC.Data
+toPlcData x =
+    let BuiltinData d = toBuiltinData x in d
+
+toLedgerData
+    :: (ToData a) => a -> Data ConwayEra
+toLedgerData = Data . toPlcData
+
+mkInlineDatum :: PLC.Data -> Datum ConwayEra
+mkInlineDatum d =
+    Datum
+        $ dataToBinaryData
+            (Data d :: Data ConwayEra)
+
+extractCageDatum
+    :: TxOut ConwayEra -> Maybe CageDatum
+extractCageDatum txOut =
+    case txOut ^. datumTxOutL of
+        Datum bd ->
+            let Data plcData =
+                    binaryDataToData bd
+            in  fromBuiltinData (BuiltinData plcData)
+        _ -> Nothing

--- a/cardano-mpfs-onchain/lib/Cardano/MPFS/OnChain/Script.hs
+++ b/cardano-mpfs-onchain/lib/Cardano/MPFS/OnChain/Script.hs
@@ -1,0 +1,201 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.MPFS.OnChain.Script
+    ( -- * Blueprint types
+      Blueprint (..)
+    , Validator (..)
+
+      -- * Loading
+    , loadBlueprint
+
+      -- * Compiled code extraction
+    , extractCompiledCode
+
+      -- * Parameter application
+    , applyVersion
+
+      -- * Script construction
+    , mkCageScript
+    , computeScriptHash
+    , cageScriptAddr
+    , cagePolicyId
+    ) where
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.Alonzo.Scripts
+    ( fromPlutusScript
+    , mkPlutusScript
+    )
+import Cardano.Ledger.BaseTypes (Network)
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core
+    ( Script
+    , hashScript
+    )
+import Cardano.Ledger.Credential
+    ( Credential (..)
+    , StakeReference (..)
+    )
+import Cardano.Ledger.Hashes (ScriptHash)
+import Cardano.Ledger.Mary.Value (PolicyID (..))
+import Cardano.Ledger.Plutus.Language
+    ( Language (PlutusV3)
+    , Plutus (..)
+    , PlutusBinary (..)
+    )
+import Data.Aeson
+    ( FromJSON (..)
+    , withObject
+    , (.:)
+    , (.:?)
+    )
+import Data.Aeson qualified as Aeson
+import Data.ByteString qualified as BS
+import Data.ByteString.Short qualified as SBS
+import Data.Char (isDigit)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Word (Word8)
+import PlutusCore qualified as PLC
+import PlutusCore.Data (Data (..))
+import PlutusLedgerApi.V3
+    ( serialiseUPLC
+    , uncheckedDeserialiseUPLC
+    )
+import UntypedPlutusCore
+    ( Program (..)
+    , applyProgram
+    )
+import UntypedPlutusCore qualified as UPLC
+
+data Validator = Validator
+    { vTitle :: Text
+    , vHash :: Text
+    , vCompiledCode :: Maybe Text
+    }
+    deriving stock (Show, Eq)
+
+data Blueprint = Blueprint
+    { validators :: [Validator]
+    }
+    deriving stock (Show, Eq)
+
+instance FromJSON Validator where
+    parseJSON = withObject "Validator" $ \o -> do
+        title <- o .: "title"
+        h <- o .: "hash"
+        code <- o .:? "compiledCode"
+        pure
+            Validator
+                { vTitle = title
+                , vHash = h
+                , vCompiledCode = code
+                }
+
+instance FromJSON Blueprint where
+    parseJSON = withObject "Blueprint" $ \o -> do
+        vs <- o .: "validators"
+        pure Blueprint{validators = vs}
+
+loadBlueprint
+    :: FilePath -> IO (Either String Blueprint)
+loadBlueprint path = do
+    bs <- BS.readFile path
+    pure $ Aeson.eitherDecodeStrict' bs
+
+extractCompiledCode
+    :: Text -> Blueprint -> Maybe SBS.ShortByteString
+extractCompiledCode prefix bp = do
+    v <-
+        case filter
+            (T.isPrefixOf prefix . vTitle)
+            (validators bp) of
+            (x : _) -> Just x
+            [] -> Nothing
+    hex <- vCompiledCode v
+    SBS.toShort <$> decodeHex hex
+
+decodeHex :: Text -> Maybe BS.ByteString
+decodeHex t
+    | odd (T.length t) = Nothing
+    | otherwise =
+        BS.pack <$> go (T.unpack t)
+  where
+    go [] = Just []
+    go (a : b : rest) = do
+        hi <- hexDigit a
+        lo <- hexDigit b
+        (hi * 16 + lo :) <$> go rest
+    go _ = Nothing
+
+    hexDigit :: Char -> Maybe Word8
+    hexDigit c
+        | isDigit c =
+            Just
+                $ fromIntegral
+                    (fromEnum c - fromEnum '0')
+        | c >= 'a' && c <= 'f' =
+            Just
+                $ fromIntegral
+                    (fromEnum c - fromEnum 'a' + 10)
+        | c >= 'A' && c <= 'F' =
+            Just
+                $ fromIntegral
+                    (fromEnum c - fromEnum 'A' + 10)
+        | otherwise = Nothing
+
+applyVersion
+    :: Integer -> SBS.ShortByteString -> SBS.ShortByteString
+applyVersion ver sbs =
+    let prog = uncheckedDeserialiseUPLC sbs
+        argProg =
+            Program
+                ()
+                (progVer prog)
+                ( UPLC.Constant
+                    ()
+                    ( PLC.Some
+                        ( PLC.ValueOf
+                            PLC.DefaultUniData
+                            (I ver)
+                        )
+                    )
+                )
+        applied = case applyProgram prog argProg of
+            Right p -> p
+            Left e ->
+                error
+                    $ "applyVersion: "
+                        <> show e
+    in  serialiseUPLC applied
+  where
+    progVer (Program _ v _) = v
+
+mkCageScript
+    :: SBS.ShortByteString -> Script ConwayEra
+mkCageScript sbs =
+    let plutus =
+            Plutus @PlutusV3
+                $ PlutusBinary sbs
+    in  case mkPlutusScript plutus of
+            Just ps -> fromPlutusScript ps
+            Nothing ->
+                error
+                    "mkCageScript: invalid \
+                    \PlutusV3 script"
+
+computeScriptHash
+    :: SBS.ShortByteString -> ScriptHash
+computeScriptHash sbs =
+    hashScript @ConwayEra (mkCageScript sbs)
+
+cagePolicyId :: SBS.ShortByteString -> PolicyID
+cagePolicyId = PolicyID . computeScriptHash
+
+cageScriptAddr
+    :: SBS.ShortByteString -> Network -> Addr
+cageScriptAddr sbs net =
+    Addr
+        net
+        (ScriptHashObj $ computeScriptHash sbs)
+        StakeRefNull

--- a/cardano-mpfs-onchain/lib/Cardano/MPFS/OnChain/Types.hs
+++ b/cardano-mpfs-onchain/lib/Cardano/MPFS/OnChain/Types.hs
@@ -1,0 +1,576 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.MPFS.OnChain.Types
+    ( -- * On-chain datum\/redeemer types
+      CageDatum (..)
+    , MintRedeemer (..)
+    , Mint (..)
+    , Migration (..)
+    , UpdateRedeemer (..)
+
+      -- * On-chain domain types
+    , OnChainTokenId (..)
+    , OnChainOperation (..)
+    , OnChainRoot (..)
+    , OnChainRequest (..)
+    , OnChainTokenState (..)
+    , OnChainTxOutRef (..)
+
+      -- * Proof steps (Aiken MPF proof encoding)
+    , ProofStep (..)
+    , Neighbor (..)
+    ) where
+
+import Data.ByteString (ByteString)
+import PlutusCore.Data (Data (..))
+import PlutusTx.Builtins.Internal
+    ( BuiltinByteString (..)
+    , BuiltinData (..)
+    )
+import PlutusTx.IsData.Class
+    ( FromData (..)
+    , ToData (..)
+    , UnsafeFromData (..)
+    )
+
+-- ---------------------------------------------------------
+-- On-chain domain types (Plutus primitives)
+-- ---------------------------------------------------------
+
+newtype OnChainTokenId = OnChainTokenId
+    { unOnChainTokenId :: BuiltinByteString
+    }
+    deriving stock (Show, Eq)
+
+data OnChainTxOutRef = OnChainTxOutRef
+    { txOutRefId :: !BuiltinByteString
+    , txOutRefIdx :: !Integer
+    }
+    deriving stock (Show, Eq)
+
+newtype OnChainRoot = OnChainRoot
+    { unOnChainRoot :: ByteString
+    }
+    deriving stock (Show, Eq)
+
+data OnChainOperation
+    = OpInsert !ByteString
+    | OpDelete !ByteString
+    | OpUpdate !ByteString !ByteString
+    deriving stock (Show, Eq)
+
+data OnChainRequest = OnChainRequest
+    { requestToken :: !OnChainTokenId
+    , requestOwner :: !BuiltinByteString
+    , requestKey :: !ByteString
+    , requestValue :: !OnChainOperation
+    , requestTip :: !Integer
+    , requestSubmittedAt :: !Integer
+    }
+    deriving stock (Show, Eq)
+
+data OnChainTokenState = OnChainTokenState
+    { stateOwner :: !BuiltinByteString
+    , stateRoot :: !OnChainRoot
+    , stateTip :: !Integer
+    , stateProcessTime :: !Integer
+    , stateRetractTime :: !Integer
+    }
+    deriving stock (Show, Eq)
+
+-- ---------------------------------------------------------
+-- On-chain-only types (datum / redeemer wrappers)
+-- ---------------------------------------------------------
+
+data CageDatum
+    = RequestDatum !OnChainRequest
+    | StateDatum !OnChainTokenState
+    deriving stock (Show, Eq)
+
+data MintRedeemer
+    = Minting !Mint
+    | Migrating !Migration
+    | Burning
+    deriving stock (Show, Eq)
+
+newtype Mint = Mint
+    { mintAsset :: OnChainTxOutRef
+    }
+    deriving stock (Show, Eq)
+
+data Migration = Migration
+    { migrationOldPolicy :: !BuiltinByteString
+    , migrationTokenId :: !OnChainTokenId
+    }
+    deriving stock (Show, Eq)
+
+data UpdateRedeemer
+    = End
+    | Contribute !OnChainTxOutRef
+    | Modify ![[ProofStep]]
+    | Retract !OnChainTxOutRef
+    | Reject
+    deriving stock (Show, Eq)
+
+data ProofStep
+    = Branch
+        { branchSkip :: !Integer
+        , branchNeighbors :: !ByteString
+        }
+    | Fork
+        { forkSkip :: !Integer
+        , forkNeighbor :: !Neighbor
+        }
+    | Leaf
+        { leafSkip :: !Integer
+        , leafKey :: !ByteString
+        , leafValue :: !ByteString
+        }
+    deriving stock (Show, Eq)
+
+data Neighbor = Neighbor
+    { neighborNibble :: !Integer
+    , neighborPrefix :: !ByteString
+    , neighborRoot :: !ByteString
+    }
+    deriving stock (Show, Eq)
+
+-- ---------------------------------------------------------
+-- Helpers for manual Data construction
+-- ---------------------------------------------------------
+
+mkD :: Data -> BuiltinData
+mkD = BuiltinData
+
+unD :: BuiltinData -> Data
+unD (BuiltinData d) = d
+
+bsToD :: ByteString -> Data
+bsToD = B
+
+bsFromD :: Data -> Maybe ByteString
+bsFromD (B bs) = Just bs
+bsFromD _ = Nothing
+
+bbsToD :: BuiltinByteString -> Data
+bbsToD (BuiltinByteString bs) = B bs
+
+bbsFromD :: Data -> Maybe BuiltinByteString
+bbsFromD (B bs) = Just (BuiltinByteString bs)
+bbsFromD _ = Nothing
+
+-- ---------------------------------------------------------
+-- ToData / FromData instances
+-- ---------------------------------------------------------
+
+instance ToData OnChainTokenId where
+    toBuiltinData (OnChainTokenId bbs) =
+        mkD $ Constr 0 [bbsToD bbs]
+
+instance FromData OnChainTokenId where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [x] ->
+            OnChainTokenId <$> bbsFromD x
+        _ -> Nothing
+
+instance UnsafeFromData OnChainTokenId where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [x] -> case bbsFromD x of
+            Just bbs -> OnChainTokenId bbs
+            _ ->
+                error
+                    "unsafeFromBuiltinData: OnChainTokenId"
+        _ ->
+            error
+                "unsafeFromBuiltinData: OnChainTokenId"
+
+instance ToData OnChainTxOutRef where
+    toBuiltinData OnChainTxOutRef{..} =
+        mkD
+            $ Constr
+                0
+                [bbsToD txOutRefId, I txOutRefIdx]
+
+instance FromData OnChainTxOutRef where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [tid, I idx] ->
+            OnChainTxOutRef
+                <$> bbsFromD tid
+                <*> pure idx
+        _ -> Nothing
+
+instance UnsafeFromData OnChainTxOutRef where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [B tid, I idx] ->
+            OnChainTxOutRef
+                (BuiltinByteString tid)
+                idx
+        _ ->
+            error
+                "unsafeFromBuiltinData: OnChainTxOutRef"
+
+instance ToData OnChainOperation where
+    toBuiltinData (OpInsert v) =
+        mkD $ Constr 0 [bsToD v]
+    toBuiltinData (OpDelete v) =
+        mkD $ Constr 1 [bsToD v]
+    toBuiltinData (OpUpdate old new) =
+        mkD $ Constr 2 [bsToD old, bsToD new]
+
+instance FromData OnChainOperation where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [v] -> OpInsert <$> bsFromD v
+        Constr 1 [v] -> OpDelete <$> bsFromD v
+        Constr 2 [o, n] ->
+            OpUpdate <$> bsFromD o <*> bsFromD n
+        _ -> Nothing
+
+instance UnsafeFromData OnChainOperation where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [B v] -> OpInsert v
+        Constr 1 [B v] -> OpDelete v
+        Constr 2 [B o, B n] -> OpUpdate o n
+        _ ->
+            error
+                "unsafeFromBuiltinData: OnChainOperation"
+
+instance ToData OnChainRoot where
+    toBuiltinData (OnChainRoot bs) = mkD $ bsToD bs
+
+instance FromData OnChainRoot where
+    fromBuiltinData bd =
+        OnChainRoot <$> bsFromD (unD bd)
+
+instance UnsafeFromData OnChainRoot where
+    unsafeFromBuiltinData bd = case unD bd of
+        B bs -> OnChainRoot bs
+        _ ->
+            error
+                "unsafeFromBuiltinData: OnChainRoot"
+
+instance ToData OnChainRequest where
+    toBuiltinData OnChainRequest{..} =
+        mkD
+            $ Constr
+                0
+                [ unD (toBuiltinData requestToken)
+                , bbsToD requestOwner
+                , bsToD requestKey
+                , unD (toBuiltinData requestValue)
+                , I requestTip
+                , I requestSubmittedAt
+                ]
+
+instance FromData OnChainRequest where
+    fromBuiltinData bd = case unD bd of
+        Constr
+            0
+            [tok, own, k, val, I tip, I sub] -> do
+                requestToken <-
+                    fromBuiltinData (mkD tok)
+                requestOwner <- bbsFromD own
+                requestKey <- bsFromD k
+                requestValue <-
+                    fromBuiltinData (mkD val)
+                let requestTip = tip
+                    requestSubmittedAt = sub
+                Just OnChainRequest{..}
+        _ -> Nothing
+
+instance UnsafeFromData OnChainRequest where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr
+            0
+            [tok, B own, B k, val, I tip, I sub] ->
+                OnChainRequest
+                    { requestToken =
+                        unsafeFromBuiltinData (mkD tok)
+                    , requestOwner =
+                        BuiltinByteString own
+                    , requestKey = k
+                    , requestValue =
+                        unsafeFromBuiltinData (mkD val)
+                    , requestTip = tip
+                    , requestSubmittedAt = sub
+                    }
+        _ ->
+            error
+                "unsafeFromBuiltinData:\
+                \ OnChainRequest"
+
+instance ToData OnChainTokenState where
+    toBuiltinData OnChainTokenState{..} =
+        mkD
+            $ Constr
+                0
+                [ bbsToD stateOwner
+                , unD (toBuiltinData stateRoot)
+                , I stateTip
+                , I stateProcessTime
+                , I stateRetractTime
+                ]
+
+instance FromData OnChainTokenState where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [own, r, I tip, I pt, I rt] -> do
+            stateOwner <- bbsFromD own
+            stateRoot <- fromBuiltinData (mkD r)
+            let stateTip = tip
+                stateProcessTime = pt
+                stateRetractTime = rt
+            Just OnChainTokenState{..}
+        _ -> Nothing
+
+instance UnsafeFromData OnChainTokenState where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [B own, r, I tip, I pt, I rt] ->
+            OnChainTokenState
+                { stateOwner =
+                    BuiltinByteString own
+                , stateRoot =
+                    unsafeFromBuiltinData (mkD r)
+                , stateTip = tip
+                , stateProcessTime = pt
+                , stateRetractTime = rt
+                }
+        _ ->
+            error
+                "unsafeFromBuiltinData:\
+                \ OnChainTokenState"
+
+instance ToData CageDatum where
+    toBuiltinData (RequestDatum r) =
+        mkD
+            $ Constr 0 [unD (toBuiltinData r)]
+    toBuiltinData (StateDatum s) =
+        mkD
+            $ Constr 1 [unD (toBuiltinData s)]
+
+instance FromData CageDatum where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            RequestDatum
+                <$> fromBuiltinData (mkD d)
+        Constr 1 [d] ->
+            StateDatum
+                <$> fromBuiltinData (mkD d)
+        _ -> Nothing
+
+instance UnsafeFromData CageDatum where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            RequestDatum
+                $ unsafeFromBuiltinData (mkD d)
+        Constr 1 [d] ->
+            StateDatum
+                $ unsafeFromBuiltinData (mkD d)
+        _ -> error "unsafeFromBuiltinData: CageDatum"
+
+instance ToData Mint where
+    toBuiltinData (Mint ref) =
+        mkD $ Constr 0 [unD (toBuiltinData ref)]
+
+instance FromData Mint where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            Mint <$> fromBuiltinData (mkD d)
+        _ -> Nothing
+
+instance UnsafeFromData Mint where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            Mint $ unsafeFromBuiltinData (mkD d)
+        _ -> error "unsafeFromBuiltinData: Mint"
+
+instance ToData Migration where
+    toBuiltinData Migration{..} =
+        mkD
+            $ Constr
+                0
+                [ bbsToD migrationOldPolicy
+                , unD
+                    (toBuiltinData migrationTokenId)
+                ]
+
+instance FromData Migration where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [pol, tid] -> do
+            migrationOldPolicy <- bbsFromD pol
+            migrationTokenId <-
+                fromBuiltinData (mkD tid)
+            Just Migration{..}
+        _ -> Nothing
+
+instance UnsafeFromData Migration where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [B pol, tid] ->
+            Migration
+                { migrationOldPolicy =
+                    BuiltinByteString pol
+                , migrationTokenId =
+                    unsafeFromBuiltinData (mkD tid)
+                }
+        _ ->
+            error
+                "unsafeFromBuiltinData: Migration"
+
+instance ToData MintRedeemer where
+    toBuiltinData (Minting m) =
+        mkD $ Constr 0 [unD (toBuiltinData m)]
+    toBuiltinData (Migrating m) =
+        mkD $ Constr 1 [unD (toBuiltinData m)]
+    toBuiltinData Burning =
+        mkD $ Constr 2 []
+
+instance FromData MintRedeemer where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            Minting <$> fromBuiltinData (mkD d)
+        Constr 1 [d] ->
+            Migrating <$> fromBuiltinData (mkD d)
+        Constr 2 [] -> Just Burning
+        _ -> Nothing
+
+instance UnsafeFromData MintRedeemer where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [d] ->
+            Minting $ unsafeFromBuiltinData (mkD d)
+        Constr 1 [d] ->
+            Migrating
+                $ unsafeFromBuiltinData (mkD d)
+        Constr 2 [] -> Burning
+        _ ->
+            error
+                "unsafeFromBuiltinData: MintRedeemer"
+
+instance ToData Neighbor where
+    toBuiltinData Neighbor{..} =
+        mkD
+            $ Constr
+                0
+                [ I neighborNibble
+                , bsToD neighborPrefix
+                , bsToD neighborRoot
+                ]
+
+instance FromData Neighbor where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [I nib, pfx, rt] ->
+            Neighbor nib
+                <$> bsFromD pfx
+                <*> bsFromD rt
+        _ -> Nothing
+
+instance UnsafeFromData Neighbor where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [I nib, B pfx, B rt] ->
+            Neighbor nib pfx rt
+        _ -> error "unsafeFromBuiltinData: Neighbor"
+
+instance ToData ProofStep where
+    toBuiltinData Branch{..} =
+        mkD
+            $ Constr
+                0
+                [ I branchSkip
+                , bsToD branchNeighbors
+                ]
+    toBuiltinData Fork{..} =
+        mkD
+            $ Constr
+                1
+                [ I forkSkip
+                , unD (toBuiltinData forkNeighbor)
+                ]
+    toBuiltinData Leaf{..} =
+        mkD
+            $ Constr
+                2
+                [ I leafSkip
+                , bsToD leafKey
+                , bsToD leafValue
+                ]
+
+instance FromData ProofStep where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [I sk, nb] ->
+            Branch sk <$> bsFromD nb
+        Constr 1 [I sk, nd] ->
+            Fork sk
+                <$> fromBuiltinData (mkD nd)
+        Constr 2 [I sk, k, v] ->
+            Leaf sk <$> bsFromD k <*> bsFromD v
+        _ -> Nothing
+
+instance UnsafeFromData ProofStep where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [I sk, B nb] -> Branch sk nb
+        Constr 1 [I sk, nd] ->
+            Fork sk
+                $ unsafeFromBuiltinData (mkD nd)
+        Constr 2 [I sk, B k, B v] -> Leaf sk k v
+        _ ->
+            error "unsafeFromBuiltinData: ProofStep"
+
+instance ToData UpdateRedeemer where
+    toBuiltinData End = mkD $ Constr 0 []
+    toBuiltinData (Contribute ref) =
+        mkD $ Constr 1 [unD (toBuiltinData ref)]
+    toBuiltinData (Modify proofs) =
+        mkD
+            $ Constr
+                2
+                [ List
+                    ( map
+                        ( List
+                            . map
+                                (unD . toBuiltinData)
+                        )
+                        proofs
+                    )
+                ]
+    toBuiltinData (Retract ref) =
+        mkD $ Constr 3 [unD (toBuiltinData ref)]
+    toBuiltinData Reject = mkD $ Constr 4 []
+
+instance FromData UpdateRedeemer where
+    fromBuiltinData bd = case unD bd of
+        Constr 0 [] -> Just End
+        Constr 1 [d] ->
+            Contribute <$> fromBuiltinData (mkD d)
+        Constr 2 [List ps] ->
+            Modify <$> traverse parseProof ps
+          where
+            parseProof (List steps) =
+                traverse
+                    (fromBuiltinData . mkD)
+                    steps
+            parseProof _ = Nothing
+        Constr 3 [d] ->
+            Retract <$> fromBuiltinData (mkD d)
+        Constr 4 [] -> Just Reject
+        _ -> Nothing
+
+instance UnsafeFromData UpdateRedeemer where
+    unsafeFromBuiltinData bd = case unD bd of
+        Constr 0 [] -> End
+        Constr 1 [d] ->
+            Contribute
+                $ unsafeFromBuiltinData (mkD d)
+        Constr 2 [List ps] ->
+            Modify $ map parseProof ps
+          where
+            parseProof (List steps) =
+                map (unsafeFromBuiltinData . mkD) steps
+            parseProof _ =
+                error
+                    "unsafeFromBuiltinData:\
+                    \ UpdateRedeemer"
+        Constr 3 [d] ->
+            Retract
+                $ unsafeFromBuiltinData (mkD d)
+        Constr 4 [] -> Reject
+        _ ->
+            error
+                "unsafeFromBuiltinData:\
+                \ UpdateRedeemer"

--- a/e2e/src/cage.ts
+++ b/e2e/src/cage.ts
@@ -36,7 +36,7 @@ export type Validator = ReturnType<
 interface PendingRequest {
   utxo: UTxO;
   datum: string;
-  fee: bigint;
+  tip: bigint;
   lovelace: bigint;
   submittedAt: bigint;
 }
@@ -70,7 +70,7 @@ class Cage implements PromiseLike<void> {
   private unit = "";
   private stateUtxo: UTxO | undefined;
   private root = EMPTY_ROOT;
-  private maxFee = 0n;
+  private tip = 0n;
   private processTime: bigint;
   private retractTime: bigint;
   private pendingRequests: PendingRequest[] = [];
@@ -109,12 +109,12 @@ class Cage implements PromiseLike<void> {
 
   // --- Public DSL methods ---
 
-  mint(opts?: { maxFee?: bigint }): this {
+  mint(opts?: { tip?: bigint }): this {
     this.chain = this.chain.then(() => this.doMint(opts));
     return this;
   }
 
-  request(key: string, value: string, opts?: { fee?: bigint }): this {
+  request(key: string, value: string, opts?: { tip?: bigint }): this {
     this.chain = this.chain.then(() =>
       this.doRequest(key, value, false, opts),
     );
@@ -124,7 +124,7 @@ class Cage implements PromiseLike<void> {
   deleteRequest(
     key: string,
     value: string,
-    opts?: { fee?: bigint },
+    opts?: { tip?: bigint },
   ): this {
     this.chain = this.chain.then(() =>
       this.doRequest(key, value, true, opts),
@@ -162,8 +162,8 @@ class Cage implements PromiseLike<void> {
 
   // --- Private step implementations ---
 
-  private async doMint(opts?: { maxFee?: bigint }): Promise<void> {
-    this.maxFee = opts?.maxFee ?? 0n;
+  private async doMint(opts?: { tip?: bigint }): Promise<void> {
+    this.tip = opts?.tip ?? 0n;
 
     const utxos = await this.lucid.wallet().getUtxos();
     expect(utxos.length).toBeGreaterThan(0);
@@ -179,7 +179,7 @@ class Cage implements PromiseLike<void> {
     const datum = encodeStateDatum(
       this.ownerKeyHash,
       EMPTY_ROOT,
-      this.maxFee,
+      this.tip,
       this.processTime,
       this.retractTime,
     );
@@ -206,9 +206,9 @@ class Cage implements PromiseLike<void> {
     key: string,
     value: string,
     isDelete: boolean,
-    opts?: { fee?: bigint },
+    opts?: { tip?: bigint },
   ): Promise<void> {
-    const fee = opts?.fee ?? 0n;
+    const tip = opts?.tip ?? 0n;
     const lovelace = 2_000_000n;
     const submittedAt = BigInt(Date.now()) + onChainTimeOffset;
     const encode = isDelete
@@ -219,7 +219,7 @@ class Cage implements PromiseLike<void> {
       this.ownerKeyHash,
       key,
       value,
-      fee,
+      tip,
       submittedAt,
     );
 
@@ -249,7 +249,7 @@ class Cage implements PromiseLike<void> {
     this.pendingRequests.push({
       utxo: requestUtxo!,
       datum,
-      fee,
+      tip,
       lovelace,
       submittedAt,
     });
@@ -262,7 +262,7 @@ class Cage implements PromiseLike<void> {
     const newDatum = encodeStateDatum(
       this.ownerKeyHash,
       newRoot,
-      this.maxFee,
+      this.tip,
       this.processTime,
       this.retractTime,
     );
@@ -284,16 +284,32 @@ class Cage implements PromiseLike<void> {
         { [this.unit]: 1n, lovelace: 2_000_000n },
       );
 
-    // Refund each requester
-    for (const req of this.pendingRequests) {
-      txBuilder = txBuilder.pay.ToAddress(this.walletAddress, {
-        lovelace: req.lovelace - req.fee,
-      });
-    }
+    // Conservation-exact refunds with overestimated fee.
+    // setMinFee locks tx.fee before evaluation so the
+    // validator sees the same fee used to compute refunds.
+    // The ledger accepts fee >= min_fee; excess goes to
+    // the Cardano treasury.
+    const overestimatedFee = 1_000_000n;
+    const n = BigInt(this.pendingRequests.length);
+    const totalInputLovelace = this.pendingRequests.reduce(
+      (sum, r) => sum + r.lovelace, 0n);
+    const totalRefund = totalInputLovelace - overestimatedFee - n * this.tip;
+    const perRequest = n > 0n ? totalRefund / n : 0n;
+    const remainder = n > 0n ? totalRefund % n : 0n;
+
+    this.pendingRequests.forEach((_req, i) => {
+      const refund = perRequest + (BigInt(i) === 0n ? remainder : 0n);
+      if (refund > 0n) {
+        txBuilder = txBuilder.pay.ToAddress(this.walletAddress, {
+          lovelace: refund,
+        });
+      }
+    });
 
     const tx = await txBuilder
       .attach.SpendingValidator(this.validator.spendValidator)
       .addSignerKey(this.ownerKeyHash)
+      .setMinFee(overestimatedFee)
       .complete(COMPLETE_OPTS);
 
     await this.submitAndWait(tx);
@@ -318,7 +334,7 @@ class Cage implements PromiseLike<void> {
     const datum = encodeStateDatum(
       this.ownerKeyHash,
       this.root,
-      this.maxFee,
+      this.tip,
       this.processTime,
       this.retractTime,
     );
@@ -360,12 +376,20 @@ class Cage implements PromiseLike<void> {
     const sameDatum = encodeStateDatum(
       this.ownerKeyHash,
       this.root,
-      this.maxFee,
+      this.tip,
       this.processTime,
       this.retractTime,
     );
 
     const now = BigInt(Date.now());
+
+    const overestimatedFee = 1_000_000n;
+    const n = BigInt(this.pendingRequests.length);
+    const totalInputLovelace = this.pendingRequests.reduce(
+      (sum, r) => sum + r.lovelace, 0n);
+    const totalRefund = totalInputLovelace - overestimatedFee - n * this.tip;
+    const perRequest = n > 0n ? totalRefund / n : 0n;
+    const remainder = n > 0n ? totalRefund % n : 0n;
 
     let txBuilder = this.lucid
       .newTx()
@@ -382,19 +406,19 @@ class Cage implements PromiseLike<void> {
         { [this.unit]: 1n, lovelace: 2_000_000n },
       );
 
-    // Refund each requester (lovelace minus fee)
-    for (const req of this.pendingRequests) {
-      const refund = req.lovelace - req.fee;
+    this.pendingRequests.forEach((_req, i) => {
+      const refund = perRequest + (BigInt(i) === 0n ? remainder : 0n);
       if (refund > 0n) {
         txBuilder = txBuilder.pay.ToAddress(this.walletAddress, {
           lovelace: refund,
         });
       }
-    }
+    });
 
     const tx = await txBuilder
       .attach.SpendingValidator(this.validator.spendValidator)
       .addSignerKey(this.ownerKeyHash)
+      .setMinFee(overestimatedFee)
       .complete(COMPLETE_OPTS);
 
     await this.submitAndWait(tx);

--- a/e2e/src/codec.ts
+++ b/e2e/src/codec.ts
@@ -1,7 +1,7 @@
 import { Constr, Data, type UTxO } from "@lucid-evolution/lucid";
 
 // CageDatum = RequestDatum(Request) | StateDatum(State)
-// StateDatum is constructor index 1, State has fields { owner, root, max_fee, process_time, retract_time }
+// StateDatum is constructor index 1, State has fields { owner, root, tip, process_time, retract_time }
 export function encodeStateDatum(
   owner: string,
   root: string,
@@ -84,7 +84,7 @@ export function encodeRequestDatum(
   ownerHash: string,
   key: string,
   value: string,
-  fee: bigint = 0n,
+  tip: bigint = 0n,
   submittedAt: bigint = 0n,
 ): string {
   const tokenId = new Constr(0, [assetName]);
@@ -94,7 +94,7 @@ export function encodeRequestDatum(
     ownerHash,
     key,
     operation,
-    fee,
+    tip,
     submittedAt,
   ]);
   return Data.to(new Constr(0, [request]));
@@ -106,7 +106,7 @@ export function encodeDeleteRequestDatum(
   ownerHash: string,
   key: string,
   value: string,
-  fee: bigint = 0n,
+  tip: bigint = 0n,
   submittedAt: bigint = 0n,
 ): string {
   const tokenId = new Constr(0, [assetName]);
@@ -116,7 +116,7 @@ export function encodeDeleteRequestDatum(
     ownerHash,
     key,
     operation,
-    fee,
+    tip,
     submittedAt,
   ]);
   return Data.to(new Constr(0, [request]));

--- a/e2e/src/migration.test.ts
+++ b/e2e/src/migration.test.ts
@@ -44,7 +44,7 @@ describe("MPF Cage Migration E2E", () => {
       .end();
   });
 
-  it("modify with fee enforces refund to requester", async () => {
+  it("modify with tip enforces refund to requester", async () => {
     await cage(
       lucid,
       loadValidator(0),
@@ -53,8 +53,8 @@ describe("MPF Cage Migration E2E", () => {
       PROCESS_TIME,
       RETRACT_TIME,
     )
-      .mint({ maxFee: 500_000n })
-      .request(INSERT_KEY, INSERT_VALUE, { fee: 500_000n })
+      .mint({ tip: 500_000n })
+      .request(INSERT_KEY, INSERT_VALUE, { tip: 500_000n })
       .modify(MODIFIED_ROOT)
       .end();
   });

--- a/validators/cage.ak
+++ b/validators/cage.ak
@@ -516,7 +516,7 @@ pub fn is_rejectable(
 /// Non-request inputs are skipped without consuming an action.
 fn mkAction(
   tokenId,
-  max_fee,
+  state_tip,
   process_time,
   retract_time,
   validity_range,
@@ -527,11 +527,13 @@ fn mkAction(
       MerklePatriciaForestry,
       List<RequestAction>,
       List<Pair<VerificationKeyHash, Int>>,
+      Int,
     ),
   ) -> (
     MerklePatriciaForestry,
     List<RequestAction>,
     List<Pair<VerificationKeyHash, Int>>,
+    Int,
   ) {
     when input.output.datum is {
       InlineDatum(datum) ->
@@ -541,13 +543,14 @@ fn mkAction(
             requestKey,
             requestValue,
             requestOwner,
-            fee,
+            tip,
             submitted_at,
           } = request
           if requestToken == tokenId {
-            expect fee == max_fee
-            let (root, actions, refunds) = acc
+            expect tip == state_tip
+            let (root, actions, owners, totalInputLovelace) = acc
             let action, actionsTail <- uncons(actions)
+            let inputLovelace = assets.lovelace_of(input.output.value)
             let newRoot =
               when action is {
                 UpdateAction(proof) -> {
@@ -583,15 +586,13 @@ fn mkAction(
                   root
                 }
               }
-            let inputLovelace = assets.lovelace_of(input.output.value)
-            let refundAmount = inputLovelace - fee
-            let newRefunds =
-              if refundAmount > 0 {
-                [Pair(requestOwner, refundAmount), ..refunds]
+            let newOwners =
+              if inputLovelace > 0 {
+                [Pair(requestOwner, inputLovelace), ..owners]
               } else {
-                refunds
+                owners
               }
-            (newRoot, actionsTail, newRefunds)
+            (newRoot, actionsTail, newOwners, totalInputLovelace + inputLovelace)
           } else {
             acc
           }
@@ -603,23 +604,26 @@ fn mkAction(
   }
 }
 
-/// Verify that refund outputs match the expected refunds.
+/// Sum refund output lovelaces, verifying each goes
+/// to the correct owner.
 ///
-/// Walks the output list in parallel with the refunds list.
-/// For each refund, checks that the output pays at least
-/// the refund amount to the correct owner address.
-fn verifyRefunds(
+/// Walks the output list in parallel with the owners
+/// list. Returns the total lovelace across all refund
+/// outputs.
+fn sumRefunds(
   outputs: List<Output>,
-  refunds: List<Pair<VerificationKeyHash, Int>>,
-) -> Bool {
-  when refunds is {
-    [] -> True
-    [Pair(owner, amount), ..rest] -> {
+  owners: List<Pair<VerificationKeyHash, Int>>,
+) -> Int {
+  when owners is {
+    [] -> 0
+    [Pair(owner, _), ..rest] -> {
       expect [output, ..remaining] = outputs
-      expect address.VerificationKey(vkh) = output.address.payment_credential
+      expect
+        address.VerificationKey(vkh) =
+          output.address.payment_credential
       expect vkh == owner
-      expect assets.lovelace_of(output.value) >= amount
-      verifyRefunds(remaining, rest)
+      assets.lovelace_of(output.value)
+        + sumRefunds(remaining, rest)
     }
   }
 }
@@ -639,8 +643,8 @@ fn validModify(
   tx: Transaction,
   actions: List<RequestAction>,
 ) {
-  let Transaction { outputs, inputs, validity_range, .. } = tx
-  let State { root, max_fee, process_time, retract_time, .. } = state
+  let Transaction { outputs, inputs, validity_range, fee: tx_fee, .. } = tx
+  let State { root, tip, process_time, retract_time, .. } = state
   expect Some(output) = head(outputs)
   expect InlineDatum(outState) = output.datum
   expect
@@ -656,13 +660,13 @@ fn validModify(
   expect process_time == outProcessTime
   expect retract_time == outRetractTime
 
-  let (expectedNewRoot, _, refunds) =
+  let (expectedNewRoot, _, owners, totalInputLovelace) =
     inputs
       |> foldl(
-          (mpf.from_root(root), actions, []),
+          (mpf.from_root(root), actions, [], 0),
           mkAction(
             tokenId,
-            max_fee,
+            tip,
             process_time,
             retract_time,
             validity_range,
@@ -672,10 +676,13 @@ fn validModify(
   expect
     output.address.payment_credential == input.output.address.payment_credential
 
-  // Verify refund outputs (starting after the State UTxO at index 0)
+  // Verify refund outputs via conservation equation.
+  // Total refunded must equal total input lovelace minus tx fee minus N * tip.
+  let n = list.length(owners)
   expect [_, ..refundOutputs] = outputs
-  let orderedRefunds = list.reverse(refunds)
-  expect verifyRefunds(refundOutputs, orderedRefunds)
+  let orderedOwners = list.reverse(owners)
+  let totalRefunded = sumRefunds(refundOutputs, orderedOwners)
+  expect totalRefunded == totalInputLovelace - tx_fee - n * tip
   True
 }
 

--- a/validators/cage.tests.ak
+++ b/validators/cage.tests.ak
@@ -79,7 +79,7 @@ const state =
   State {
     owner: "owner",
     root: root(mpf.empty),
-    max_fee: 0,
+    tip: 0,
     process_time: testProcessTime,
     retract_time: testRetractTime,
   }
@@ -98,7 +98,7 @@ const aRequest =
       requestKey: "42",
       requestValue: Insert("42"),
       requestOwner: "owner",
-      fee: 0,
+      tip: 0,
       submitted_at: 0,
     },
   )
@@ -137,7 +137,7 @@ const output =
         State {
           owner: "new-owner",
           root: #"484dee386bcb51e285896271048baf6ea4396b2ee95be6fd29a92a0eeb8462ea",
-          max_fee: 0,
+          tip: 0,
           process_time: testProcessTime,
           retract_time: testRetractTime,
         },
@@ -203,7 +203,7 @@ const minted =
         State {
           owner: "owner",
           root: root(empty),
-          max_fee: 0,
+          tip: 0,
           process_time: testProcessTime,
           retract_time: testRetractTime,
         },
@@ -299,7 +299,7 @@ test mint_to_wrong_script() fail {
 /// A non-empty root would mean data exists without ever being inserted.
 test mint_nonempty_root() fail {
   let bad_output =
-    Output { ..minted, datum: InlineDatum(StateDatum(State { owner: "owner", root: "nonempty_root", max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })) }
+    Output { ..minted, datum: InlineDatum(StateDatum(State { owner: "owner", root: "nonempty_root", tip: 0, process_time: testProcessTime, retract_time: testRetractTime })) }
   cage.mpfCage.mint(
     0,
     Minting(minting), "policy_id",
@@ -315,7 +315,7 @@ test mint_request_datum() fail {
       ..minted,
       datum: InlineDatum(RequestDatum(Request {
         requestToken: token, requestKey: "k", requestValue: Insert("v"),
-        requestOwner: "owner", fee: 0, submitted_at: 0,
+        requestOwner: "owner", tip: 0, submitted_at: 0,
       })),
     }
   cage.mpfCage.mint(
@@ -379,7 +379,7 @@ test retract_in_phase3() fail {
 test contribute_wrong_token() fail {
   let wrong_request = RequestDatum(Request {
     requestToken: TokenId { assetName: "different_asset" },
-    requestKey: "42", requestValue: Insert("42"), requestOwner: "owner", fee: 0, submitted_at: 0,
+    requestKey: "42", requestValue: Insert("42"), requestOwner: "owner", tip: 0, submitted_at: 0,
   })
   cage.mpfCage.spend(0, Some(wrong_request), Contribute(testStateRef), testRequestRef,
     Transaction { ..transaction.placeholder, validity_range: phase1Range, inputs: [update, request] })
@@ -440,7 +440,7 @@ test modify_owner_transfer() {
 test modify_no_requests() {
   let unchanged_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   cage.mpfCage.spend(0, stateDatum, Modify([]), testStateRef,
@@ -453,7 +453,7 @@ test modify_no_requests() {
 test modify_skip_other_token() {
   let other_request_datum = RequestDatum(Request {
     requestToken: TokenId { assetName: "other_token" },
-    requestKey: "42", requestValue: Insert("42"), requestOwner: "someone", fee: 0, submitted_at: 0,
+    requestKey: "42", requestValue: Insert("42"), requestOwner: "someone", tip: 0, submitted_at: 0,
   })
   let other_request = Input {
     output_reference: OutputReference { transaction_id: "3334567890abcdef", output_index: 1 },
@@ -461,7 +461,7 @@ test modify_skip_other_token() {
   }
   let unchanged_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   cage.mpfCage.spend(0, stateDatum, Modify([]), testStateRef,
@@ -487,7 +487,7 @@ test modify_extra_proofs() {
 test modify_wrong_root() fail {
   let bad_root_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "new-owner", root: "wrong_root_hash", max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "new-owner", root: "wrong_root_hash", tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   cage.mpfCage.spend(0, stateDatum, Modify([UpdateAction([])]), testStateRef,
@@ -602,7 +602,7 @@ fn owner_fuzzer() -> Fuzzer<ByteArray> {
 test prop_retract_requires_owner(signer via owner_fuzzer()) fail once {
   let req = RequestDatum(Request {
     requestToken: testToken, requestKey: "k", requestValue: Insert("v"),
-    requestOwner: "the_real_owner_key_aaaaaaaaaa", fee: 0, submitted_at: 0,
+    requestOwner: "the_real_owner_key_aaaaaaaaaa", tip: 0, submitted_at: 0,
   })
   cage.mpfCage.spend(0, Some(req), Retract(testStateRef), testRequestRef,
     Transaction { ..transaction.placeholder, validity_range: phase2Range, extra_signatories: [signer], reference_inputs: [update] })
@@ -615,10 +615,10 @@ test prop_retract_requires_owner(signer via owner_fuzzer()) fail once {
 /// doesn't match the state owner. This verifies `has(extra_signatories, owner)`
 /// protects the MPF state from unauthorized modifications.
 test prop_modify_requires_owner(signer via owner_fuzzer()) fail once {
-  let s = State { owner: "the_real_owner_key_aaaaaaaaaa", root: root(empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime }
+  let s = State { owner: "the_real_owner_key_aaaaaaaaaa", root: root(empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime }
   let unchanged_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "the_real_owner_key_aaaaaaaaaa", root: root(empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "the_real_owner_key_aaaaaaaaaa", root: root(empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   let state_input = Input {
@@ -647,7 +647,7 @@ test prop_mint_roundtrip(params via fuzz.tuple(fuzz.bytearray_fixed(32), fuzz.in
   let addr = address.from_script("policy_id")
   let out = Output {
     address: addr, value: val,
-    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "owner", root: root(empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   let utxo = Output { address: paying_address, value: zero, datum: NoDatum, reference_script: None }
@@ -679,7 +679,7 @@ const migrate_output =
   Output {
     address: address.from_script(new_policy),
     value: from_asset(new_policy, migrate_token.assetName, 1),
-    datum: InlineDatum(StateDatum(State { owner: "owner", root: "nonempty_root_hash_aaaaaaaaa", max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "owner", root: "nonempty_root_hash_aaaaaaaaa", tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
 
@@ -725,13 +725,13 @@ test migrate_wrong_old_policy() fail {
 
 const testFee = 500_000
 
-const feeState = State { owner: "owner", root: root(mpf.empty), max_fee: testFee, process_time: testProcessTime, retract_time: testRetractTime }
+const feeState = State { owner: "owner", root: root(mpf.empty), tip: testFee, process_time: testProcessTime, retract_time: testRetractTime }
 
 const feeStateDatum = Some(StateDatum(feeState))
 
 const feeRequest = RequestDatum(Request {
   requestToken: testToken, requestKey: "42", requestValue: Insert("42"),
-  requestOwner: "requester_key_aaaaaaaaaaaaaaa", fee: testFee, submitted_at: 0,
+  requestOwner: "requester_key_aaaaaaaaaaaaaaa", tip: testFee, submitted_at: 0,
 })
 
 const feeRequestInput = Input {
@@ -747,7 +747,7 @@ const feeStateInput = Input {
 const feeStateOutput = Output {
   address: testScriptAddress, value: testValue,
   datum: InlineDatum(StateDatum(State {
-    owner: "new-owner", root: #"484dee386bcb51e285896271048baf6ea4396b2ee95be6fd29a92a0eeb8462ea", max_fee: testFee,
+    owner: "new-owner", root: #"484dee386bcb51e285896271048baf6ea4396b2ee95be6fd29a92a0eeb8462ea", tip: testFee,
     process_time: testProcessTime, retract_time: testRetractTime,
   })),
   reference_script: None,
@@ -791,10 +791,10 @@ test modify_wrong_refund_address() fail {
 /// When fee is 0, the full input ADA is refunded. No ADA is retained by the
 /// cage owner. This is the "free service" case.
 test modify_zero_fee() {
-  let zf_state = State { owner: "owner", root: root(mpf.empty), max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime }
+  let zf_state = State { owner: "owner", root: root(mpf.empty), tip: 0, process_time: testProcessTime, retract_time: testRetractTime }
   let zf_request = RequestDatum(Request {
     requestToken: testToken, requestKey: "42", requestValue: Insert("42"),
-    requestOwner: "requester_key_aaaaaaaaaaaaaaa", fee: 0, submitted_at: 0,
+    requestOwner: "requester_key_aaaaaaaaaaaaaaa", tip: 0, submitted_at: 0,
   })
   let zf_request_input = Input {
     output_reference: testRequestRef,
@@ -806,7 +806,7 @@ test modify_zero_fee() {
   }
   let zf_state_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "new-owner", root: #"484dee386bcb51e285896271048baf6ea4396b2ee95be6fd29a92a0eeb8462ea", max_fee: 0, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "new-owner", root: #"484dee386bcb51e285896271048baf6ea4396b2ee95be6fd29a92a0eeb8462ea", tip: 0, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   let zf_refund = Output {
@@ -817,12 +817,12 @@ test modify_zero_fee() {
     Transaction { ..transaction.placeholder, validity_range: phase1Range, outputs: [zf_state_output, zf_refund], extra_signatories: ["owner"], inputs: [zf_state_input, zf_request_input] })
 }
 
-/// The request's fee must match the state's max_fee. A mismatch means the
+/// The request's tip must match the state's tip. A mismatch means the
 /// request was created for a different fee tier and must be rejected.
 test modify_fee_mismatch() fail {
   let mismatch_request = RequestDatum(Request {
     requestToken: testToken, requestKey: "42", requestValue: Insert("42"),
-    requestOwner: "requester_key_aaaaaaaaaaaaaaa", fee: 100_000, submitted_at: 0,
+    requestOwner: "requester_key_aaaaaaaaaaaaaaa", tip: 100_000, submitted_at: 0,
   })
   let mismatch_input = Input {
     output_reference: testRequestRef,
@@ -850,7 +850,7 @@ test end_with_extra_mint_policy() {
 
 const rejectStateOutput = Output {
   address: testScriptAddress, value: testValue,
-  datum: InlineDatum(StateDatum(State { owner: "owner", root: root(mpf.empty), max_fee: testFee, process_time: testProcessTime, retract_time: testRetractTime })),
+  datum: InlineDatum(StateDatum(State { owner: "owner", root: root(mpf.empty), tip: testFee, process_time: testProcessTime, retract_time: testRetractTime })),
   reference_script: None,
 }
 
@@ -879,7 +879,7 @@ test reject_in_phase2() fail {
 test reject_future_submitted_at() {
   let future_request = RequestDatum(Request {
     requestToken: testToken, requestKey: "42", requestValue: Insert("42"),
-    requestOwner: "requester_key_aaaaaaaaaaaaaaa", fee: testFee, submitted_at: 100_000,
+    requestOwner: "requester_key_aaaaaaaaaaaaaaa", tip: testFee, submitted_at: 100_000,
   })
   let future_request_input = Input {
     output_reference: testRequestRef,
@@ -899,7 +899,7 @@ test reject_missing_signature() fail {
 test reject_root_changes() fail {
   let bad_reject_output = Output {
     address: testScriptAddress, value: testValue,
-    datum: InlineDatum(StateDatum(State { owner: "owner", root: "different_root_aaaaaaaaaaaaa", max_fee: testFee, process_time: testProcessTime, retract_time: testRetractTime })),
+    datum: InlineDatum(StateDatum(State { owner: "owner", root: "different_root_aaaaaaaaaaaaa", tip: testFee, process_time: testProcessTime, retract_time: testRetractTime })),
     reference_script: None,
   }
   cage.mpfCage.spend(0, feeStateDatum, Modify([Rejected]), testStateRef,

--- a/validators/types.ak
+++ b/validators/types.ak
@@ -209,9 +209,10 @@ pub type State {
   /// The current Merkle Patricia Forestry root hash.
   /// This commits to all key-value pairs stored in the MPF.
   root: ByteArray,
-  /// The maximum fee (in lovelace) the oracle charges per request.
-  /// Requesters must agree to this fee by recording it in their Request datum.
-  max_fee: Int,
+  /// The oracle's tip per request (in lovelace).
+  /// Requesters agree to this tip by recording it in their Request datum.
+  /// The actual tx fee is split across requests at Modify time (Plutus V3).
+  tip: Int,
   /// Duration (in milliseconds) of Phase 1 — the oracle processing window.
   /// Set at mint time; enforced immutable across Modify/Reject operations.
   process_time: Int,
@@ -313,9 +314,9 @@ pub type Request {
   /// The operation to perform on the key.
   /// See `Operation` type for details on Insert, Delete, and Update.
   requestValue: Operation,
-  /// The fee (in lovelace) the requester agrees to pay.
-  /// Must match `state.max_fee` at Modify time.
-  fee: Int,
+  /// The oracle tip (in lovelace) the requester agrees to pay.
+  /// Must match `state.tip` at Modify time.
+  tip: Int,
   /// The POSIXTime (in milliseconds) when the request was submitted.
   /// Used for time-gated phase enforcement: Phase 1 (oracle-only),
   /// Phase 2 (requester retract), Phase 3 (oracle reject/cleanup).


### PR DESCRIPTION
## Summary

- `State.max_fee` → `State.tip` (oracle margin per request)
- `Request.fee` → `Request.tip` (requester agrees to oracle tip)
- `mkAction` accumulator tracks `totalInputLovelace` for conservation
- Refund verification via conservation equation: `totalRefunded == totalInputLovelace - tx.fee - N * tip`
- Replaces per-request fixed fee deduction with Plutus V3 `tx.fee` proportional split

Fresh implementation on top of [#40](https://github.com/cardano-foundation/cardano-mpfs-onchain/pull/40) (mixed update/reject). Supersedes [#36](https://github.com/cardano-foundation/cardano-mpfs-onchain/pull/36) and [#37](https://github.com/cardano-foundation/cardano-mpfs-onchain/pull/37).

Closes #35

## Test plan

- [x] 87 Aiken tests pass (0 failures)
- [x] Conservation equation exercised in refund tests