### PR TITLE
docs: update for cage merge and haskell package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # Cardano MPFS Onchain
 
-Aiken validators for [Merkle Patricia Forestry](https://github.com/aiken-lang/merkle-patricia-forestry) on Cardano (Plutus V3).
+Aiken validators and Haskell off-chain library for [Merkle Patricia Forestry](https://github.com/aiken-lang/merkle-patricia-forestry) on Cardano (Plutus V3).
 
-The on-chain component defines a **cage** pattern: an NFT locked at a script address carries the current MPF root hash as its datum. Modifications are verified on-chain via cryptographic proofs.
+The on-chain component defines a **cage** pattern: an NFT locked at a script address carries the current MPF root hash as its datum. Modifications are verified on-chain via cryptographic proofs. Time-gated phases prevent race conditions between the oracle and requesters.
 
-This repository contains the on-chain validators extracted from [cardano-foundation/mpfs](https://github.com/cardano-foundation/mpfs) (`on_chain/` directory). See the upstream [documentation](https://cardano-foundation.github.io/mpfs/) for the full MPFS system including the off-chain TypeScript service.
+## Repository structure
+
+| Directory | Language | Contents |
+|-----------|----------|----------|
+| `validators/` | Aiken | Cage minting policy + spending validator |
+| `lean/` | Lean 4 | Formal proofs of phase exclusivity and token handling |
+| `haskell/` | Haskell | Off-chain types, tx builders, test vectors, E2E tests |
+
+The `haskell/` package (`cardano-mpfs-cage`) is the single source of truth for all Haskell cage code — PlutusData type encodings, transaction builders, MPF proof serialization, and cross-language test vectors.
 
 ## Documentation
 
@@ -15,19 +23,23 @@ Full documentation is available at **[cardano-foundation.github.io/cardano-mpfs-
 - [Validators](https://cardano-foundation.github.io/cardano-mpfs-onchain/architecture/validators/) — minting policy and spending validator logic
 - [Types & Encodings](https://cardano-foundation.github.io/cardano-mpfs-onchain/architecture/types/) — datum, redeemer, and operation structures
 - [Proof System](https://cardano-foundation.github.io/cardano-mpfs-onchain/architecture/proofs/) — MPF proof format, verification, and performance
-- [Security Properties](https://cardano-foundation.github.io/cardano-mpfs-onchain/architecture/properties/) — 17 invariants verified by 44 tests
+- [Security Properties](https://cardano-foundation.github.io/cardano-mpfs-onchain/architecture/properties/) — 16 categories verified by 80 tests
+- [Haskell Cage Library](https://cardano-foundation.github.io/cardano-mpfs-onchain/haskell-cage/) — off-chain types, tx builders, test vectors
 
-## Quick Start
+## Quick start
 
 ```sh
-# Build plutus.json
+# Build plutus.json (Aiken validators)
 nix build
 
-# Enter dev shell
-nix develop
+# Run Aiken tests
+nix run .#cage-tests
 
-# Run tests (44 tests, 242 checks)
-nix develop --command aiken check
+# Run Haskell QuickCheck tests
+nix run .#cage-tests
+
+# Enter dev shell (Haskell + Aiken + Lean)
+nix develop
 ```
 
 ## License

--- a/docs/architecture/types.md
+++ b/docs/architecture/types.md
@@ -123,22 +123,34 @@ type MintRedeemer {
 ### Spending Redeemer
 
 ```aiken
+type RequestAction {
+    Update(List<Proof>)
+    Rejected
+}
+
 type UpdateRedeemer {
     End
     Contribute(OutputReference)
-    Modify(List<Proof>)
+    Modify(List<RequestAction>)
     Retract(OutputReference)
-    Reject
 }
 ```
+
+Each request in a `Modify` transaction carries a `RequestAction`:
+
+| Constructor | Index | Fields | Description |
+|---|---|---|---|
+| `Update` | 0 | `List<Proof>` | Apply proofs to update the MPF root |
+| `Rejected` | 1 | — | Reject an expired request (Phase 3 or dishonest `submitted_at`) |
+
+The spending redeemer:
 
 | Constructor | Index | Fields | Description |
 |---|---|---|---|
 | `End` | 0 | — | Destroy the MPF instance |
-| `Contribute` | 1 | `OutputReference` | Spend a request during update or reject; points to the state UTxO |
-| `Modify` | 2 | `List<Proof>` | Update the MPF root; one proof per request. Phase 1 only |
-| `Retract` | 3 | `OutputReference` | Cancel a request and reclaim ADA. Points to the State UTxO (included as reference input). Phase 2 only |
-| `Reject` | 4 | — | Discard expired/dishonest requests, refund ADA minus fee. Phase 3 or dishonest `submitted_at` |
+| `Contribute` | 1 | `OutputReference` | Spend a request during Modify; points to the state UTxO |
+| `Modify` | 2 | `List<RequestAction>` | Process requests — each can be updated or rejected in a single transaction |
+| `Retract` | 3 | `OutputReference` | Cancel a request and reclaim ADA. Points to the State UTxO (reference input). Phase 2 only |
 
 ## Plutus Data Encoding
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,7 +19,7 @@ The output is a symlink `result` pointing to the produced `plutus.json`.
 
 ## Development shell
 
-Drop into a shell with `aiken` available:
+The default shell provides GHC, cabal, Aiken, Lean, fourmolu, and hlint:
 
 ```sh
 just develop
@@ -27,21 +27,95 @@ just develop
 nix develop
 ```
 
+An Aiken-only lightweight shell is also available:
+
+```sh
+just develop-aiken
+# or: nix develop .#aiken
+```
+
 ## Testing
 
-Run the Aiken test suite (requires aiken in PATH or from `nix develop`):
+### Aiken tests
+
+Run the Aiken test suite (unit tests + property tests):
 
 ```sh
 just test
 ```
 
+### Haskell tests
+
+Run QuickCheck property tests for PlutusData roundtrips and constructor indices:
+
+```sh
+nix run .#cage-tests
+```
+
+### Lean proofs
+
+Build the formal proofs (phase exclusivity, token handling):
+
+```sh
+cd lean && lake build
+```
+
+## Nix checks and apps
+
+The flake exposes checks (sandboxed derivations) and apps (runnable wrappers):
+
+| Check | What it verifies |
+|-------|-----------------|
+| `library` | Haskell cage library compiles |
+| `cage-tests` | QuickCheck property tests pass |
+| `cage-test-vectors` | Test vector generator builds |
+| `lint` | fourmolu + hlint pass |
+| `vectors-freshness` | Committed `cage_vectors.ak` matches generated output |
+
+```sh
+# Build all checks
+nix build .#checks.x86_64-linux.library
+nix build .#checks.x86_64-linux.cage-tests
+
+# Run tests with stdout visible
+nix run .#cage-tests
+nix run .#lint
+```
+
+## Test vectors
+
+The Haskell cage library includes a test vector generator
+(`cage-test-vectors`) that produces deterministic test data in
+two formats:
+
+- **Aiken** (`--aiken`): generates `cage_vectors.ak` used by the
+  Aiken unit tests for cross-language validation
+- **JSON** (default): language-neutral vectors for any backend
+
+```sh
+# Regenerate Aiken vectors and format them
+just generate-vectors
+
+# Check committed vectors are up to date
+just vectors-check
+```
+
+CI runs `vectors-freshness` to ensure committed vectors match the
+Haskell reference.
+
 ## Justfile recipes
 
-| Recipe        | Description                              |
-| ------------- | ---------------------------------------- |
-| `just build`  | Build `plutus.json` via Nix              |
-| `just develop`| Enter dev shell with `aiken`             |
-| `just test`   | Run `aiken check` tests                  |
+| Recipe | Description |
+|--------|-------------|
+| `just build` | Build `plutus.json` via Nix |
+| `just develop` | Enter dev shell (Haskell + Aiken + Lean) |
+| `just develop-aiken` | Enter Aiken-only dev shell |
+| `just aiken-build` | Build blueprint directly with `aiken` |
+| `just test` | Run `aiken check` tests |
+| `just generate-vectors` | Regenerate `cage_vectors.ak` from Haskell |
+| `just vectors-check` | Verify committed vectors are fresh |
+| `just haskell-build` | Build Haskell cage library with cabal |
+| `just haskell-e2e` | Run Haskell E2E tests against a devnet |
 
 ## How the Nix build works
 
@@ -53,10 +127,7 @@ using `fetchFromGitHub` and populates `build/packages/` before
 running `aiken build`. This avoids network access inside the Nix
 sandbox.
 
-## Upstream
-
-The validators originate from the
-[cardano-foundation/mpfs](https://github.com/cardano-foundation/mpfs)
-repository (`on_chain/` directory). See the upstream
-[documentation](https://cardano-foundation.github.io/mpfs/) for the
-full MPFS system including the off-chain TypeScript service.
+The Haskell cage library is built via
+[haskell.nix](https://github.com/input-output-hk/haskell.nix)
+with GHC 9.8.4 and dependencies from
+[CHaP](https://github.com/intersectmbo/cardano-haskell-packages).

--- a/docs/haskell-cage.md
+++ b/docs/haskell-cage.md
@@ -1,0 +1,93 @@
+# Haskell Cage Library
+
+The `haskell/` directory contains `cardano-mpfs-cage`, a Haskell
+package that provides everything needed to build and submit cage
+transactions off-chain.
+
+## What it provides
+
+### On-chain type encodings
+
+Hand-written `ToData`/`FromData` instances matching the Aiken
+validator byte-for-byte. These are the canonical Haskell
+representation — the
+[offchain service](https://github.com/lambdasistemi/cardano-mpfs-offchain)
+imports them as re-exports.
+
+- `Cardano.MPFS.Cage.Types` — `CageDatum`, `UpdateRedeemer`,
+  `MintRedeemer`, `RequestAction`, `ProofStep`, `Neighbor`,
+  and all on-chain domain types
+- `Cardano.MPFS.Cage.AssetName` — deterministic asset-name
+  derivation matching Aiken's `lib.assetName`
+
+### MPF proof serialization
+
+- `Cardano.MPFS.Cage.Proof` — converts `MPFProof` from
+  [haskell-mts](https://github.com/lambdasistemi/haskell-mts)
+  to on-chain `ProofStep` lists and Aiken-compatible CBOR
+
+### Blueprint loading
+
+- `Cardano.MPFS.Cage.Blueprint` — CIP-57 `plutus.json` parser,
+  compiled code extraction, and UPLC version parameter application
+
+### Transaction builders
+
+All cage protocol transactions, using the
+[TxBuild DSL](https://github.com/lambdasistemi/cardano-node-clients)
+for convergent fee balancing:
+
+| Module | Transaction | Description |
+|--------|------------|-------------|
+| `TxBuilder.Boot` | Mint | Create a new cage token with empty trie |
+| `TxBuilder.Request` | Pay-to-script | Submit an insert/delete/update request |
+| `TxBuilder.Update` | Modify | Process requests, update root, refund requesters |
+| `TxBuilder.Reject` | Modify (rejected) | Discard expired Phase 3 requests |
+| `TxBuilder.Retract` | Retract | Cancel a request in Phase 2 |
+| `TxBuilder.End` | Burn | Destroy the cage token |
+
+### In-memory MPF trie
+
+- `Cardano.MPFS.Cage.Trie` — record-of-functions interface
+- `Cardano.MPFS.Cage.Trie.Pure` — `IORef`-backed implementation
+  using [haskell-mts](https://github.com/lambdasistemi/haskell-mts)
+- `Cardano.MPFS.Cage.Trie.PureManager` — per-token trie management
+  with speculative sessions for proof generation
+
+## Test vectors
+
+The `cage-test-vectors` executable generates deterministic test
+data for cross-language validation:
+
+```sh
+# JSON format (for any backend)
+nix run .#cage-test-vectors
+
+# Aiken format (for validator unit tests)
+nix run .#cage-test-vectors -- --aiken
+```
+
+Vectors include:
+- MPF proof roundtrips (insert, fork, shared prefix, inclusion)
+- Asset name derivation (various txId/index combinations)
+- Datum/redeemer PlutusData encodings (all constructors)
+
+## QuickCheck tests
+
+Property-based tests verify:
+- `ToData`/`FromData` roundtrip for every type
+- Constructor indices match Aiken (0-indexed)
+- Asset name determinism, uniqueness, and length
+
+```sh
+nix run .#cage-tests
+```
+
+## Dependencies
+
+- [cardano-node-clients](https://github.com/lambdasistemi/cardano-node-clients) —
+  TxBuild DSL, fee balancing, N2C provider
+- [haskell-mts](https://github.com/lambdasistemi/haskell-mts) —
+  in-memory MPF trie (`mts:mpf`)
+- [CHaP](https://github.com/intersectmbo/cardano-haskell-packages) —
+  Cardano ledger libraries

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,8 @@
 # Cardano MPFS Onchain
 
-Aiken validators for
+Aiken validators and Haskell off-chain library for
 [Merkle Patricia Forestry](https://github.com/aiken-lang/merkle-patricia-forestry)
 on Cardano (Plutus V3).
-
-This repository contains the on-chain component of the
-[MPFS project](https://github.com/cardano-foundation/mpfs)
-by the Cardano Foundation. The validators were originally developed in
-[`on_chain/`](https://github.com/cardano-foundation/mpfs/tree/main/on_chain)
-of that repository.
 
 The on-chain component defines a **cage** pattern: an NFT locked at
 a script address carries the current MPF root hash as its datum.
@@ -16,11 +10,20 @@ Modifications are verified on-chain via cryptographic proofs.
 Time-gated phases prevent race conditions between the oracle and
 requesters, and a Reject mechanism enables DDoS protection.
 
+## Repository structure
+
+| Directory | Language | Contents |
+|-----------|----------|----------|
+| `validators/` | Aiken | Cage minting policy + spending validator |
+| `lean/` | Lean 4 | Formal proofs of phase exclusivity and token handling |
+| `haskell/` | Haskell | Off-chain types, tx builders, test vectors, E2E tests |
+
 ## Documentation
 
-- [Development](development.md) — building, dev shell, justfile recipes
+- [Development](development.md) — building, dev shell, nix checks, justfile recipes
 - [Architecture Overview](architecture/overview.md) — system diagram, transaction lifecycle, protocol flow
 - [Validators](architecture/validators.md) — minting policy and spending validator logic
 - [Types & Encodings](architecture/types.md) — datum, redeemer, and operation structures
 - [Proof System](architecture/proofs.md) — MPF proof format, verification, and performance
 - [Security Properties](architecture/properties.md) — 16 categories verified by 80 tests
+- [Haskell Cage Library](haskell-cage.md) — off-chain types, tx builders, test vectors

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Development: development.md
+  - Haskell Cage Library: haskell-cage.md
   - Architecture:
       - Overview: architecture/overview.md
       - Validators: architecture/validators.md


### PR DESCRIPTION
Update all documentation to reflect the cage merge and new haskell/ package.

- README: repo structure table, correct test counts, remove TypeScript reference
- Development: nix checks/apps, test vectors, all justfile recipes
- New page: Haskell Cage Library (types, tx builders, proofs, test vectors)
- Types: UpdateRedeemer updated to show RequestAction (Update/Rejected)
- mkdocs nav: add haskell-cage page