### PR TITLE
feat(cage): depend on pure cardano-tx-tools:tx-build sublibrary

### DIFF
--- a/haskell/cabal.project
+++ b/haskell/cabal.project
@@ -76,8 +76,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-tx-tools
-  tag: 97374ffb611d08d2e0e7c17dfdac5699ac2b3ed8
-  --sha256: 0jsnq3hbay8y12jc0sz3jqdd99rrhkiqc0qkppf37hc3qv46p5fx
+  tag: 631f1341fde6e4a11e94b058cf5f2925ffeb9eac
+  --sha256: 0asp3sx7hd8hip739kbz65986jlv8qx9342m9gqpqcxih6pxfgjj
 
 source-repository-package
   type: git
@@ -88,6 +88,13 @@ source-repository-package
 -- chain-follower has data-default <0.8 but cardano-ledger-shelley pulls 0.8
 allow-newer: chain-follower:data-default
 allow-newer: mts:containers
+
+-- cardano-mpfs-cage uses only the pure cardano-tx-tools:tx-build sublibrary
+-- (Cardano.Tx.Build/Balance/Ledger). Disable the node-tools components so
+-- cabal does not solve their ouroboros 3.x / chain-follower closure, which
+-- conflicts with this project's ouroboros-consensus ==1.0.0.0 pin.
+package cardano-tx-tools
+  flags: -build-node-tools
 
 constraints:
   contra-tracer-contrib +iohk,

--- a/haskell/cardano-mpfs-cage.cabal
+++ b/haskell/cardano-mpfs-cage.cabal
@@ -47,7 +47,7 @@ library
     , cardano-ledger-core
     , cardano-ledger-mary
     , cardano-slotting
-    , cardano-tx-tools
+    , cardano-tx-tools:tx-build
     , containers             >=0.6  && <0.8
     , crypton
     , memory
@@ -135,7 +135,7 @@ test-suite e2e-tests
     , cardano-node-clients
     , cardano-node-clients:devnet
     , cardano-strict-containers
-    , cardano-tx-tools
+    , cardano-tx-tools:tx-build
     , containers
     , hspec
     , microlens


### PR DESCRIPTION
## What

`cardano-mpfs-cage` (library + e2e-test) uses only the pure
`Cardano.Tx.{Build,Balance,Ledger}` surface, now carved into the
cross-target **`cardano-tx-tools:tx-build`** sub-library. Depend on it
directly instead of the full `cardano-tx-tools` library.

- Bump the `cardano-tx-tools` pin to `631f1341` (where `tx-build` is exposed).
- Set `cardano-tx-tools: -build-node-tools` so cabal does not solve the
  node-tools closure (chain-follower / cardano-node-clients → ouroboros 3.x),
  which conflicts with this project's `ouroboros-consensus ==1.0.0.0` pin.

## Why

Unblocks the MPFS cage-helper WASM/JS cross-target build
(lambdasistemi/cardano-mpfs-offchain#258): the cage transaction-building
closure must be free of the node/IO surface to cross-compile.

## Validation

`nix build .#checks.x86_64-linux.library` green (cardano-mpfs-cage builds
against the pure sublib with the project GHC).