### PR TITLE
feat(cage): depend on pure mpf-write / mpf-test-lib sublibraries

### DIFF
--- a/haskell/cardano-mpfs-cage.cabal
+++ b/haskell/cardano-mpfs-cage.cabal
@@ -52,8 +52,8 @@ library
     , crypton
     , memory
     , microlens
-    , mts:mpf
     , mts:mpf-test-lib
+    , mts:mpf-write
     , plutus-core
     , plutus-ledger-api
     , plutus-tx
@@ -96,7 +96,7 @@ executable cage-test-vectors
     , crypton
     , lens
     , memory
-    , mts:mpf
+    , mts:mpf-write
     , plutus-core
     , plutus-tx
     , text


### PR DESCRIPTION
## What

`cardano-mpfs-cage` depends on the pure **`mts:mpf-write`** sub-library
(and `mts:mpf-test-lib` for the library) instead of the rocksdb-bound
`mts:mpf`.

## Why

cage uses only the pure MPF surface — `MPF.Backend.Pure`, `MPF.Hashes`,
`MPF.Interface`, `MPF.Proof.Insertion`, and the `MPF.Test.Lib` in-memory
trie helpers in `Cardano.MPFS.Cage.Trie.Pure` — all exposed by `mpf-write`.
`MPF.Test.Lib` now also builds on `mpf-write` (lambdasistemi/haskell-mts#160).
Dropping the dependency on the rocksdb-bound `mts:mpf` lets the cage
transaction-building closure cross-compile to wasm32-wasi / GHC-JS.

Native builds are unchanged.

Unblocks the MPFS cage-helper wasm build
(lambdasistemi/cardano-mpfs-offchain#258).

## Validation

`nix build .#checks.x86_64-linux.library` green (cage builds against
`cardano-tx-tools:tx-build` + `mpf-write` + `mpf-test-lib`).