### PR TITLE
ci: run nix builds on builder-new self-hosted runners + setup-nix v0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted","cardano-mpfs-onchain"]') }}
     steps:
       - uses: actions/checkout@v6
 
-      - uses: paolino/dev-assets/setup-nix@v0.0.1
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
@@ -41,11 +41,11 @@ jobs:
 
   tests:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted","cardano-mpfs-onchain"]') }}
     steps:
       - uses: actions/checkout@v6
 
-      - uses: paolino/dev-assets/setup-nix@v0.0.1
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
@@ -54,11 +54,11 @@ jobs:
 
   e2e:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted","cardano-mpfs-onchain"]') }}
     steps:
       - uses: actions/checkout@v6
 
-      - uses: paolino/dev-assets/setup-nix@v0.0.1
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
@@ -83,11 +83,11 @@ jobs:
 
   lint:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted","cardano-mpfs-onchain"]') }}
     steps:
       - uses: actions/checkout@v6
 
-      - uses: paolino/dev-assets/setup-nix@v0.0.1
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
@@ -95,14 +95,14 @@ jobs:
         run: nix run .#lint
 
   lean:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('["self-hosted","cardano-mpfs-onchain"]') }}
     defaults:
       run:
         working-directory: lean
     steps:
       - uses: actions/checkout@v6
 
-      - uses: paolino/dev-assets/setup-nix@v0.0.1
+      - uses: paolino/dev-assets/setup-nix@v0.1.0
         with:
           cachix-auth-token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 


### PR DESCRIPTION
Routes all CI nix jobs (build/tests/e2e/lint/lean) to the dedicated self-hosted runners on builder-new (label `cardano-mpfs-onchain`, 64c/1.5TB) for non-fork events; fork PRs stay on GitHub-hosted (fork-guarded `runs-on`). Also bumps `setup-nix@v0.0.1 → v0.1.0`. 3 runners provisioned.