### PR TITLE
fix: drop mpf-test-lib from cage library

### DIFF
--- a/haskell/cardano-mpfs-cage.cabal
+++ b/haskell/cardano-mpfs-cage.cabal
@@ -52,7 +52,6 @@ library
     , crypton
     , memory
     , microlens
-    , mts:mpf-test-lib
     , mts:mpf-write
     , plutus-core
     , plutus-ledger-api

--- a/haskell/lib/Cardano/MPFS/Cage/Trie/Pure.hs
+++ b/haskell/lib/Cardano/MPFS/Cage/Trie/Pure.hs
@@ -31,25 +31,98 @@ import Data.IORef (
 
 import MPF.Backend.Pure (
     MPFInMemoryDB,
+    MPFPure,
     emptyMPFInMemoryDB,
     runMPFPure,
+    runMPFPureTransaction,
  )
+import MPF.Backend.Standalone (
+    MPFStandalone (..),
+    MPFStandaloneCodecs (..),
+ )
+import MPF.Deletion (deleting)
 import MPF.Hashes (
+    MPFHash,
+    isoMPFHash,
     mkMPFHash,
+    mpfHashing,
     renderMPFHash,
+    root,
  )
-import MPF.Interface (byteStringToHexKey)
-import MPF.Test.Lib (
-    deleteMPFM,
-    getRootHashM,
-    insertByteStringM,
-    proofMPFM,
+import MPF.Insertion (inserting)
+import MPF.Interface (
+    FromHexKV (..),
+    HexKey,
+    byteStringToHexKey,
+    hexKeyPrism,
+ )
+import MPF.Proof.Insertion (
+    MPFProof,
+    mkMPFInclusionProof,
  )
 
 import Cardano.MPFS.Cage.Ledger (Root (..))
 import Cardano.MPFS.Cage.Proof (toProofSteps)
 import Cardano.MPFS.Cage.Trie (Trie (..))
 import Cardano.MPFS.Cage.Types (ProofStep)
+
+mpfHashCodecs :: MPFStandaloneCodecs HexKey MPFHash MPFHash
+mpfHashCodecs =
+    MPFStandaloneCodecs
+        { mpfKeyCodec = hexKeyPrism
+        , mpfValueCodec = isoMPFHash
+        , mpfNodeCodec = isoMPFHash
+        }
+
+fromHexKVIdentity :: FromHexKV HexKey MPFHash MPFHash
+fromHexKVIdentity =
+    FromHexKV
+        { fromHexK = id
+        , fromHexV = id
+        , hexTreePrefix = const []
+        }
+
+hashKeyPath :: ByteString -> HexKey
+hashKeyPath =
+    byteStringToHexKey . renderMPFHash . mkMPFHash
+
+insertByteStringM :: ByteString -> ByteString -> MPFPure ()
+insertByteStringM k v =
+    runMPFPureTransaction mpfHashCodecs $
+        inserting
+            []
+            fromHexKVIdentity
+            mpfHashing
+            MPFStandaloneKVCol
+            MPFStandaloneMPFCol
+            (hashKeyPath k)
+            (mkMPFHash v)
+
+deleteMPFM :: HexKey -> MPFPure ()
+deleteMPFM k =
+    runMPFPureTransaction mpfHashCodecs $
+        deleting
+            []
+            fromHexKVIdentity
+            mpfHashing
+            MPFStandaloneKVCol
+            MPFStandaloneMPFCol
+            k
+
+proofMPFM :: HexKey -> MPFPure (Maybe (MPFProof MPFHash))
+proofMPFM k =
+    runMPFPureTransaction mpfHashCodecs $
+        mkMPFInclusionProof
+            []
+            fromHexKVIdentity
+            mpfHashing
+            MPFStandaloneMPFCol
+            k
+
+rootHashM :: MPFPure (Maybe ByteString)
+rootHashM =
+    runMPFPureTransaction mpfHashCodecs $
+        root MPFStandaloneMPFCol []
 
 {- | Create a new empty 'Trie IO' backed by a fresh
 'IORef' holding an empty in-memory MPF database.
@@ -126,10 +199,10 @@ pureGetRoot ref = readIORef ref >>= getRootFromDb
 -- | Get root hash from a database snapshot.
 getRootFromDb :: MPFInMemoryDB -> IO Root
 getRootFromDb db =
-    let (mHash, _) = runMPFPure db getRootHashM
+    let (mHash, _) = runMPFPure db rootHashM
      in pure $ case mHash of
             Nothing -> Root (B.replicate 32 0)
-            Just h -> Root (renderMPFHash h)
+            Just h -> Root h
 
 -- | Generate on-chain proof steps for a key.
 pureGetProofSteps ::


### PR DESCRIPTION
## Summary

- remove the `mts:mpf-test-lib` dependency from `cardano-mpfs-cage`
- replace `MPF.Test.Lib` convenience helpers in `Cardano.MPFS.Cage.Trie.Pure` with local wrappers over production `mts:mpf-write` modules
- keep the production cage library buildable when downstream wasm builds use a `haskell-mts` revision where `mpf-test-lib` is `buildable: False` under `flag(wasm)`

## Verification

- `nix build .#checks.x86_64-linux.library --print-build-logs` exits 0; `cardano-mpfs-cage` compiles all 18 modules
- `nix run .#cage-tests` exits 0; 37 examples, 0 failures
- `nix run .#lint` exits 0; HLint reports `No hints`
- `nix build --impure -f /tmp/orch-spa-ux/onchain-cage-wasm-flag-check.nix --print-build-logs` exits 0; `cardano-mpfs-cage` builds with `packages.mts.flags.wasm = true` and depends on `mts:mpf-write`, not `mts:mpf-test-lib`

Do not merge yet; this PR is intended for downstream offchain SPA integration verification first.
