### PR TITLE
Fix reject refund min-UTxO top-up invariant

### DIFF
--- a/validators/cage.tests.ak
+++ b/validators/cage.tests.ak
@@ -1524,6 +1524,73 @@ const refundOutput =
     reference_script: None,
   }
 
+const capturedRefundTip = 2_000_000
+
+const capturedRefundTxFee = 2_289_551
+
+const capturedStateValue = testValue |> assets.merge(from_lovelace(2_000_000))
+
+const capturedRefundState =
+  State {
+    owner: "owner",
+    root: root(mpf.empty),
+    tip: capturedRefundTip,
+    process_time: testProcessTime,
+    retract_time: testRetractTime,
+  }
+
+const capturedRefundStateDatum = Some(StateDatum(capturedRefundState))
+
+const capturedRefundStateInput =
+  Input {
+    output_reference: testStateRef,
+    output: Output {
+      address: testScriptAddress,
+      value: capturedStateValue,
+      datum: InlineDatum(StateDatum(capturedRefundState)),
+      reference_script: None,
+    },
+  }
+
+const capturedRefundStateOutput =
+  Output {
+    address: testScriptAddress,
+    value: capturedStateValue,
+    datum: InlineDatum(StateDatum(capturedRefundState)),
+    reference_script: None,
+  }
+
+const capturedRefundRequest =
+  RequestDatum(
+    Request {
+      requestToken: testToken,
+      requestKey: "42",
+      requestValue: Insert("42"),
+      requestOwner: "requester_key_aaaaaaaaaaaaaaa",
+      tip: capturedRefundTip,
+      submitted_at: 0,
+    },
+  )
+
+const capturedRefundRequestInput =
+  Input {
+    output_reference: testRequestRef,
+    output: Output {
+      address: testScriptAddress,
+      value: from_lovelace(5_020_709),
+      datum: InlineDatum(capturedRefundRequest),
+      reference_script: None,
+    },
+  }
+
+const capturedMinUtxoRefundOutput =
+  Output {
+    address: address.from_verification_key("requester_key_aaaaaaaaaaaaaaa"),
+    value: from_lovelace(849_070),
+    datum: NoDatum,
+    reference_script: None,
+  }
+
 /// Happy path: Modify with fee. Request has 2 ADA, fee is 0.5 ADA,
 /// so refund of 1.5 ADA goes to the requester's address.
 test modify_with_refund() {
@@ -1929,6 +1996,74 @@ test reject_wrong_refund() fail {
       outputs: [rejectStateOutput, bad_refund],
       extra_signatories: ["owner"],
       inputs: [feeStateInput, feeRequestInput],
+    },
+  )
+}
+
+test reject_refund_owed_above_min_utxo_passes() {
+  spend(
+    feeStateDatum,
+    Modify([Rejected]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      validity_range: phase3Range,
+      outputs: [rejectStateOutput, refundOutput],
+      extra_signatories: ["owner"],
+      inputs: [feeStateInput, feeRequestInput],
+    },
+  )
+}
+
+/// Captures the live failure shape: owed is 731_158 lovelace after fee and
+/// tip, but the ledger-valid refund output must carry 849_070 lovelace.
+test reject_refund_min_utxo_topup_passes() {
+  spend(
+    capturedRefundStateDatum,
+    Modify([Rejected]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      fee: capturedRefundTxFee,
+      validity_range: phase3Range,
+      outputs: [capturedRefundStateOutput, capturedMinUtxoRefundOutput],
+      extra_signatories: ["owner"],
+      inputs: [capturedRefundStateInput, capturedRefundRequestInput],
+    },
+  )
+}
+
+test reject_refund_under_owed_fails() fail {
+  let under_refund =
+    Output { ..capturedMinUtxoRefundOutput, value: from_lovelace(731_157) }
+  spend(
+    capturedRefundStateDatum,
+    Modify([Rejected]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      fee: capturedRefundTxFee,
+      validity_range: phase3Range,
+      outputs: [capturedRefundStateOutput, under_refund],
+      extra_signatories: ["owner"],
+      inputs: [capturedRefundStateInput, capturedRefundRequestInput],
+    },
+  )
+}
+
+test reject_refund_topup_cannot_drain_state() fail {
+  let drained_state = Output { ..capturedRefundStateOutput, value: testValue }
+  spend(
+    capturedRefundStateDatum,
+    Modify([Rejected]),
+    testStateRef,
+    Transaction {
+      ..transaction.placeholder,
+      fee: capturedRefundTxFee,
+      validity_range: phase3Range,
+      outputs: [drained_state, capturedMinUtxoRefundOutput],
+      extra_signatories: ["owner"],
+      inputs: [capturedRefundStateInput, capturedRefundRequestInput],
     },
   )
 }

--- a/validators/state.ak
+++ b/validators/state.ak
@@ -190,6 +190,8 @@ fn validModify(
   expect (mpf.root(expectedNewRoot) == newRoot)?
   expect
     output.address.payment_credential == input.output.address.payment_credential
+  expect
+    assets.lovelace_of(output.value) >= assets.lovelace_of(input.output.value)
   expect exactQuantity(policyId, output.value, tokenId, 1)
 
   let n = list.length(owners)
@@ -199,7 +201,13 @@ fn validModify(
       expect [_, ..refundOutputs] = outputs
       let orderedOwners = list.reverse(owners)
       let totalRefunded = sumRefunds(refundOutputs, orderedOwners)
-      expect totalRefunded == totalInputLovelace - tx_fee - n * tip
+      let owed = totalInputLovelace - tx_fee - n * tip
+      let maxRefunded = totalInputLovelace - n * tip
+      // Refunds may exceed owed only to satisfy ledger min-UTxO. The state
+      // output preserves its lovelace above, so any bounded top-up comes from
+      // owner-signed funding inputs rather than from the cage.
+      expect totalRefunded >= owed
+      expect totalRefunded <= maxRefunded
       True
     }
   }


### PR DESCRIPTION
## Summary
- Relax Modify reject refund validation from exact equality to a bounded lower/upper refund range.
- Preserve state-output lovelace so min-UTxO refund top-ups cannot be sourced by draining the cage state.
- Add Aiken regression tests for normal refunds, captured min-UTxO top-up, under-refund rejection, and cage-draining top-up rejection.

## Security Argument
The requester still receives at least the owed refund: request inputs minus tx fee minus tips. Any over-refund is bounded by the request net of tips, and the state output must preserve its input lovelace. Since Modify still requires the state owner signature and refund output ordering/address checks, the only available source for the bounded top-up is owner/funder inputs, not the cage state or another requester refund.

## Verification
- nix develop .#aiken -c aiken fmt --check
- nix develop .#aiken -c just test (116 passed, 0 failed)
- nix build

Attempted nix develop -c just haskell-build; it failed before compiling local code during dependency solving: cardano-lmdb LMDB pkg-config missing / base-4.21 bounds.
